### PR TITLE
런타임 예외 공통처리 및 예외 클래스 분리

### DIFF
--- a/src/main/java/com/flab/weshare/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/weshare/domain/user/service/UserService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.flab.weshare.domain.user.dto.SignUpRequest;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.exception.ErrorCode;
-import com.flab.weshare.exception.exceptions.CommonException;
+import com.flab.weshare.exception.exceptions.DuplicateException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,10 +18,10 @@ public class UserService {
 	@Transactional
 	public void signUp(SignUpRequest signUpRequest) {
 		if (userRepository.existsByEmail(signUpRequest.email())) {
-			throw new CommonException(ErrorCode.DUPLICATE_EMAIL);
+			throw new DuplicateException(ErrorCode.DUPLICATE_EMAIL);
 		}
 		if (userRepository.existsByNickName(signUpRequest.nickName())) {
-			throw new CommonException(ErrorCode.DUPLICATE_NICKNAME);
+			throw new DuplicateException(ErrorCode.DUPLICATE_NICKNAME);
 		}
 		userRepository.save(signUpRequest.convert());
 	}

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -4,9 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-	DUPLICATE_EMAIL("duplicate_email","이미 존재하는 이메일입니다."),
-	DUPLICATE_NICKNAME("duplicate_nickname","이미 존재하는 닉네임입니다."),
-	INVALID_INPUT("invalid_input","입력값이 올바르지 않습니다.");
+	INTRENAL_SERVER_ERROR("internal_server_error", "서버에 에러가 발생했습니다."),
+	DUPLICATE_EMAIL("duplicate_email", "이미 존재하는 이메일입니다."),
+	DUPLICATE_NICKNAME("duplicate_nickname", "이미 존재하는 닉네임입니다."),
+	INVALID_INPUT("invalid_input", "입력값이 올바르지 않습니다.");
 
 	private final String errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
+++ b/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
@@ -11,18 +11,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.flab.weshare.domain.base.BaseResponse;
 import com.flab.weshare.domain.base.ErrorResponse;
 import com.flab.weshare.exception.ErrorCode;
-import com.flab.weshare.exception.exceptions.CommonException;
+import com.flab.weshare.exception.exceptions.DuplicateException;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(RuntimeException.class)
+	public BaseResponse commonExceptionHandler(RuntimeException runtimeException) {
+		log.error("exception :", runtimeException);
+		return BaseResponse.fail(ErrorResponse.of(ErrorCode.INTRENAL_SERVER_ERROR));
+	}
+
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(CommonException.class)
-	public BaseResponse commonExceptionHandler(CommonException commonException) {
-		log.error("exception :", commonException);
-		return BaseResponse.fail(ErrorResponse.of(commonException.getErrorCode()));
+	@ExceptionHandler(DuplicateException.class)
+	public BaseResponse commonExceptionHandler(DuplicateException duplicateException) {
+		log.error("exception :", duplicateException);
+		return BaseResponse.fail(ErrorResponse.of(duplicateException.getErrorCode()));
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/flab/weshare/exception/exceptions/DuplicateException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/DuplicateException.java
@@ -1,0 +1,13 @@
+package com.flab.weshare.exception.exceptions;
+
+import com.flab.weshare.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DuplicateException extends RuntimeException{
+	private final ErrorCode errorCode;
+
+}

--- a/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
@@ -13,7 +13,7 @@ import com.flab.weshare.domain.user.dto.SignUpRequest;
 import com.flab.weshare.domain.user.entity.User;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.exception.ErrorCode;
-import com.flab.weshare.exception.exceptions.CommonException;
+import com.flab.weshare.exception.exceptions.DuplicateException;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -32,7 +32,7 @@ class UserServiceTest {
 			.willReturn(true);
 
 		assertThatThrownBy(() -> userService.signUp(signUpRequest))
-			.isInstanceOf(CommonException.class)
+			.isInstanceOf(DuplicateException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.DUPLICATE_EMAIL);
 	}
@@ -44,7 +44,7 @@ class UserServiceTest {
 			.willReturn(true);
 
 		assertThatThrownBy(() -> userService.signUp(signUpRequest))
-			.isInstanceOf(CommonException.class)
+			.isInstanceOf(DuplicateException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
 	}


### PR DESCRIPTION
## 설명
- 런타임 예외 공통처리 및 예외 클래스 분리

## 작업 내용
- 런타임 예외에 대한 공통적인 반환값을 설정하였습니다.
- `Common Exception`의 무분별한 사용이 우려되어 필드 중복에 대한 예외를 분리하였습니다.




