### PR TITLE
[#3] 스프링 시큐리티 적용 및 기본 로그인 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ repositories {
 	mavenCentral()
 }
 
+ext['spring-security.version'] = '6.1.7'
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/flab/weshare/WeshareApplication.java
+++ b/src/main/java/com/flab/weshare/WeshareApplication.java
@@ -2,15 +2,12 @@ package com.flab.weshare;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class WeshareApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(WeshareApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/flab/weshare/config/SecurityConfiguration.java
+++ b/src/main/java/com/flab/weshare/config/SecurityConfiguration.java
@@ -1,0 +1,27 @@
+package com.flab.weshare.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+			.formLogin(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests((authorizeRequests) -> authorizeRequests
+					.requestMatchers(HttpMethod.POST,"api/*/user").permitAll()
+					.requestMatchers("api/login").permitAll()
+					.anyRequest().authenticated()
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/flab/weshare/config/SecurityConfiguration.java
+++ b/src/main/java/com/flab/weshare/config/SecurityConfiguration.java
@@ -6,11 +6,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfiguration {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		return http
@@ -18,8 +25,8 @@ public class SecurityConfiguration {
 			.csrf(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-					.requestMatchers(HttpMethod.POST,"api/*/user").permitAll()
-					.requestMatchers("api/login").permitAll()
+				.requestMatchers(HttpMethod.POST, "api/*/user").permitAll()
+				.requestMatchers("api/login").permitAll()
 					.anyRequest().authenticated()
 			)
 			.build();

--- a/src/main/java/com/flab/weshare/domain/base/BaseResponse.java
+++ b/src/main/java/com/flab/weshare/domain/base/BaseResponse.java
@@ -13,7 +13,7 @@ public class BaseResponse<T> {
 	private T data;
 	private ErrorResponse errorResponse;
 
-	public static <T> BaseResponse sucesss(T data) {
+	public static <T> BaseResponse success(T data) {
 		return BaseResponse.builder()
 			.success(true)
 			.data(data)

--- a/src/main/java/com/flab/weshare/domain/user/controller/LoginController.java
+++ b/src/main/java/com/flab/weshare/domain/user/controller/LoginController.java
@@ -14,7 +14,7 @@ import com.flab.weshare.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class LoginController {
 	private final UserService userService;

--- a/src/main/java/com/flab/weshare/domain/user/controller/LoginController.java
+++ b/src/main/java/com/flab/weshare/domain/user/controller/LoginController.java
@@ -1,0 +1,27 @@
+package com.flab.weshare.domain.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.weshare.domain.base.BaseResponse;
+import com.flab.weshare.domain.user.dto.LoginRequest;
+import com.flab.weshare.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/")
+@RequiredArgsConstructor
+public class LoginController {
+	private final UserService userService;
+
+	@ResponseStatus(HttpStatus.OK)
+	@PostMapping("/login")
+	public BaseResponse loginAttempt(@RequestBody LoginRequest loginRequest) {
+		return BaseResponse.success(userService.login(loginRequest));
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/user/controller/UserController.java
+++ b/src/main/java/com/flab/weshare/domain/user/controller/UserController.java
@@ -15,7 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;

--- a/src/main/java/com/flab/weshare/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/flab/weshare/domain/user/dto/LoginRequest.java
@@ -1,0 +1,5 @@
+package com.flab.weshare.domain.user.dto;
+
+public record LoginRequest(String email, String password) {
+}
+

--- a/src/main/java/com/flab/weshare/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/flab/weshare/domain/user/dto/LoginRequest.java
@@ -1,5 +1,9 @@
 package com.flab.weshare.domain.user.dto;
 
 public record LoginRequest(String email, String password) {
+	@Override
+	public String toString() {
+		return "LoginRequest 요청";
+	}
 }
 

--- a/src/main/java/com/flab/weshare/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/flab/weshare/domain/user/dto/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.flab.weshare.domain.user.dto;
+
+import com.flab.weshare.domain.user.entity.User;
+
+public record LoginResponse(Long id, String nickName) {
+	public static LoginResponse from(User user) {
+		return new LoginResponse(user.getId(), user.getNickName());
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/com/flab/weshare/domain/user/dto/SignUpRequest.java
@@ -7,16 +7,19 @@ import com.flab.weshare.domain.user.entity.Role;
 import com.flab.weshare.domain.user.entity.User;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public record SignUpRequest(@Email(message = "이메일 형식에 맞지 않습니다.") String email,
-							@Pattern(regexp = NICKNAME_PATTERN, message = NICKNAME_MESSAGE) String nickName,
-							@Pattern(regexp = TELEPHONE_PATTERN, message = TELEPHONE_MESSAGE) String telephone) {
-	public User convert() {
+public record SignUpRequest(@NotNull @Email(message = "이메일 형식에 맞지 않습니다.") String email,
+							@NotNull @Pattern(regexp = PASSWORD_PATTERN, message = PASSWORD_MESSAGE) String password,
+							@NotNull @Pattern(regexp = NICKNAME_PATTERN, message = NICKNAME_MESSAGE) String nickName,
+							@NotNull @Pattern(regexp = TELEPHONE_PATTERN, message = TELEPHONE_MESSAGE) String telephone) {
+	public User convert(String encodedPassword) {
 
 		return User.builder()
 			.email(email)
 			.telephone(telephone)
+			.password(encodedPassword)
 			.nickName(nickName)
 			.role(Role.CLIENT)
 			.build();

--- a/src/main/java/com/flab/weshare/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/weshare/domain/user/repository/UserRepository.java
@@ -11,9 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByNickName(String nickName);
 
-	// @Query("select new com.flab.weshare.domain.user.dto.LoginResponse(u.id, u.nickName)"
-	// 	+ " from User u"
-	// 	+ " where u.email= :email and u.password= :password"
-	// )
 	Optional<User> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/com/flab/weshare/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/weshare/domain/user/repository/UserRepository.java
@@ -1,10 +1,19 @@
 package com.flab.weshare.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.flab.weshare.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
+
 	boolean existsByNickName(String nickName);
+
+	// @Query("select new com.flab.weshare.domain.user.dto.LoginResponse(u.id, u.nickName)"
+	// 	+ " from User u"
+	// 	+ " where u.email= :email and u.password= :password"
+	// )
+	Optional<User> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/com/flab/weshare/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/weshare/domain/user/service/UserService.java
@@ -1,11 +1,17 @@
 package com.flab.weshare.domain.user.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.flab.weshare.domain.user.dto.LoginRequest;
+import com.flab.weshare.domain.user.dto.LoginResponse;
 import com.flab.weshare.domain.user.dto.SignUpRequest;
+import com.flab.weshare.domain.user.entity.User;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.exception.ErrorCode;
+import com.flab.weshare.exception.exceptions.CommonClientException;
 import com.flab.weshare.exception.exceptions.DuplicateException;
 
 import lombok.RequiredArgsConstructor;
@@ -24,5 +30,20 @@ public class UserService {
 			throw new DuplicateException(ErrorCode.DUPLICATE_NICKNAME);
 		}
 		userRepository.save(signUpRequest.convert());
+	}
+
+	@Transactional(readOnly = true)
+	public LoginResponse login(LoginRequest loginRequest) {
+		List<User> all = userRepository.findAll();
+		System.out.println(all);
+
+		System.out.println(loginRequest);
+
+		User userByEmailAndPassword = userRepository.findByEmailAndPassword(
+			loginRequest.email(),
+			loginRequest.password()
+		).orElseThrow(() -> new CommonClientException(ErrorCode.USER_NOT_FOUND));
+
+		return LoginResponse.from(userByEmailAndPassword);
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/weshare/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.flab.weshare.domain.user.service;
 
 import java.util.List;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
 	public void signUp(SignUpRequest signUpRequest) {
@@ -29,7 +31,8 @@ public class UserService {
 		if (userRepository.existsByNickName(signUpRequest.nickName())) {
 			throw new DuplicateException(ErrorCode.DUPLICATE_NICKNAME);
 		}
-		userRepository.save(signUpRequest.convert());
+		String encodedPassword = passwordEncoder.encode(signUpRequest.password());
+		userRepository.save(signUpRequest.convert(encodedPassword));
 	}
 
 	@Transactional(readOnly = true)
@@ -41,7 +44,7 @@ public class UserService {
 
 		User userByEmailAndPassword = userRepository.findByEmailAndPassword(
 			loginRequest.email(),
-			loginRequest.password()
+			passwordEncoder.encode(loginRequest.password())
 		).orElseThrow(() -> new CommonClientException(ErrorCode.USER_NOT_FOUND));
 
 		return LoginResponse.from(userByEmailAndPassword);

--- a/src/main/java/com/flab/weshare/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/weshare/domain/user/service/UserService.java
@@ -1,7 +1,5 @@
 package com.flab.weshare.domain.user.service;
 
-import java.util.List;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,11 +35,6 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public LoginResponse login(LoginRequest loginRequest) {
-		List<User> all = userRepository.findAll();
-		System.out.println(all);
-
-		System.out.println(loginRequest);
-
 		User userByEmailAndPassword = userRepository.findByEmailAndPassword(
 			loginRequest.email(),
 			passwordEncoder.encode(loginRequest.password())

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
 	INTRENAL_SERVER_ERROR("internal_server_error", "서버에 에러가 발생했습니다."),
 	DUPLICATE_EMAIL("duplicate_email", "이미 존재하는 이메일입니다."),
 	DUPLICATE_NICKNAME("duplicate_nickname", "이미 존재하는 닉네임입니다."),
-	INVALID_INPUT("invalid_input", "입력값이 올바르지 않습니다.");
+	INVALID_INPUT("invalid_input", "입력값이 올바르지 않습니다."),
+	USER_NOT_FOUND("user_not_found", "입력한 로그인 정보에 해당하는 유저가 없습니다.");
 
 	private final String errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
+++ b/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.flab.weshare.domain.base.BaseResponse;
 import com.flab.weshare.domain.base.ErrorResponse;
 import com.flab.weshare.exception.ErrorCode;
-import com.flab.weshare.exception.exceptions.DuplicateException;
+import com.flab.weshare.exception.exceptions.CommonClientException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,10 +26,10 @@ public class ControllerAdvice {
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(DuplicateException.class)
-	public BaseResponse commonExceptionHandler(DuplicateException duplicateException) {
-		log.error("exception :", duplicateException);
-		return BaseResponse.fail(ErrorResponse.of(duplicateException.getErrorCode()));
+	@ExceptionHandler(CommonClientException.class)
+	public BaseResponse commonExceptionHandler(CommonClientException commonClientException) {
+		log.error("exception :", commonClientException);
+		return BaseResponse.fail(ErrorResponse.of(commonClientException.getErrorCode()));
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/flab/weshare/exception/exceptions/CommonClientException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/CommonClientException.java
@@ -1,0 +1,12 @@
+package com.flab.weshare.exception.exceptions;
+
+import com.flab.weshare.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommonClientException extends RuntimeException{
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/flab/weshare/exception/exceptions/CommonException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/CommonException.java
@@ -1,12 +1,9 @@
 package com.flab.weshare.exception.exceptions;
 
-import com.flab.weshare.exception.ErrorCode;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class CommonException extends RuntimeException{
-	private final ErrorCode errorCode;
 }

--- a/src/main/java/com/flab/weshare/exception/exceptions/DuplicateException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/DuplicateException.java
@@ -3,11 +3,10 @@ package com.flab.weshare.exception.exceptions;
 import com.flab.weshare.exception.ErrorCode;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
-public class DuplicateException extends RuntimeException{
-	private final ErrorCode errorCode;
-
+public class DuplicateException extends CommonClientException {
+	public DuplicateException(ErrorCode errorCode) {
+		super(errorCode);
+	}
 }

--- a/src/main/java/com/flab/weshare/utils/RegEx.java
+++ b/src/main/java/com/flab/weshare/utils/RegEx.java
@@ -7,10 +7,13 @@ public class RegEx {
 	public static class Pattern {
 		public static final String NICKNAME_PATTERN = "^[가-힣A-Za-z0-9]{2,6}$";
 		public static final String TELEPHONE_PATTERN = "^01(?:0|1|[6-9])(\\d{3}|\\d{4})\\d{4}$";
+		public static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$";
+
 	}
 
 	public static class Message {
 		public static final String NICKNAME_MESSAGE = "닉네임 형식에 맞지 않습니다.";
 		public static final String TELEPHONE_MESSAGE = "전화번호 형식에 맞지 않습니다.";
+		public static final String PASSWORD_MESSAGE = "전화번호 형식에 맞지 않습니다.";
 	}
 }


### PR DESCRIPTION
## 설명
- [#3] 스프링 시큐리티 적용 및 기본 로그인 API 구현 

## 작업 내용
- 스프링 시큐리티 적용
- 기본 로그인 API 구현 
- 기존 회원 가입 요청 dto에 `password` 필드가 실수로 빠졌던 것을 추가하는 것으로 수정

## 기타 사항
- `PR`의 사이즈를 최소화해야한다는 멘토님 조언을 실천하기위해서 PR을 먼저 올리고 브랜치를 새로파서 진행을 하던중 수정한 파일이 많아져서 부득이하게 현재 `PR`에 한꺼번에 올리게 되었습니다. 다음부터는 조금 더 신중히 해보겠습니다.
- 현재 커밋한 내용들은 완성이 아니며, 다음 PR에서 `JWT Token` 구현 후 로그인 및 인증 인가 서비스를 완성할 예정입니다.
