### PR TITLE
[#4] Mysql Testcontainers 라이브러리 적용, 일부 환경변수 일괄적으로 파일로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,4 +202,6 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
-# End of https://www.toptal.com/developers/gitignore/api/intellij,gradle,java,macos
+
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -1,50 +1,53 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.8'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.8'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.flab'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext['spring-security.version'] = '6.1.7'
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
+
+    testImplementation 'org.testcontainers:testcontainers:1.19.6'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.6'
+    testImplementation 'org.testcontainers:mysql:1.19.6'
+    testImplementation 'org.testcontainers:jdbc:1.19.6'
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/test/java/com/flab/weshare/config/TestContainerConfig.java
+++ b/src/test/java/com/flab/weshare/config/TestContainerConfig.java
@@ -1,0 +1,13 @@
+package com.flab.weshare.config;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class TestContainerConfig {
+	static final String MYSQL_IMAGE = "mysql:8";
+
+	@Container
+	static final MySQLContainer MY_SQL_CONTAINER = new MySQLContainer(MYSQL_IMAGE);
+}

--- a/src/test/java/com/flab/weshare/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/auth/controller/AuthControllerTest.java
@@ -14,7 +14,7 @@ import com.flab.weshare.exception.ErrorCode;
 
 public class AuthControllerTest extends BaseControllerTest {
 	LoginRequest rightloginRequest = new LoginRequest(EMAIL, PASSWORD);
-	LoginRequest wrongPasswordLoginRequest = new LoginRequest(EMAIL + "1", PASSWORD + "1");
+	LoginRequest wrongPasswordLoginRequest = new LoginRequest(EMAIL, PASSWORD + "1");
 
 	@DisplayName("로그인 성공시 액세스 토큰과 리프레시 토큰 반환")
 	@Test

--- a/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
@@ -6,14 +6,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.weshare.config.TestContainerConfig;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.utils.jwt.JwtUtil;
 
+@ActiveProfiles("test")
 @Transactional
+@Import({TestContainerConfig.class})
 @SpringBootTest
 @AutoConfigureMockMvc
 public abstract class BaseControllerTest {

--- a/src/test/java/com/flab/weshare/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/user/controller/UserControllerTest.java
@@ -24,7 +24,7 @@ class UserControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
-	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "test", "01011111111");
+	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "fffdfdf2@", "test", "01011111111");
 
 	@Test
 	void signup_test() throws Exception {

--- a/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
@@ -23,7 +23,7 @@ class UserServiceTest {
 	@Mock
 	UserRepository userRepository;
 
-	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "test", "01011111111");
+	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "fffdfdf2@", "test", "01011111111");
 
 	@Test
 	void signUp_중복_이메일() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    import: optional:file:.env[.properties]
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8:///
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 설명
- [#4] Mysql 테스트 컨테이너 라이브러리 적용

## 작업 내용
- 테스트 컨테이너 의존성 추가
- 외부 노출 되지 말아야할 환경변수를 `.env`파일로 분리

## 부가설명
현재 개발 환경과 테스트 환경 에서 `H2 In-memory` 방식을 사용하는 환경을 향후 배포 환경에서 사용할 `Mysql 8.X`과의 환경을 일치시키기 위해 도커 위에서 테스트를 진행하는 `Testcontainers`를 도입했습니다. 
