### PR TITLE
[#13] 어플리케이션 설정 파일 환경별로 분리

### DIFF
--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -1,18 +1,18 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+
   datasource:
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-    url: jdbc:tc:mysql:8:///
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USER_NAME}
+    password: ${DB_PASSWORD}
 
   jpa:
     open-in-view: false
-    hibernate:
-      ddl-auto: create
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
 
 jwt:
   access_expiration_time: ${JWT_ACCESS_EXPIRATION_TIME}
   refresh_expiration_time: ${JWT_REFRESH_EXPIRATION_TIME}
   secret: ${JWT_SECRET}
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,6 @@
+spring:
+  jpa:
+    show-sql: false
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,6 @@
 spring:
-  jpa:
-    show-sql: true
-
-jwt:
-  access_expiration_time: ${JWT_ACCESS_EXPIRATION_TIME}
-  refresh_expiration_time: ${JWT_REFRESH_EXPIRATION_TIME}
-  secret: ${JWT_SECRET}
-
-decorator:
-  datasource:
-    p6spy:
-      enable-logging: true
+  profiles:
+    default: local
+    group:
+      "local": "local, common"
+      "prod": "prod, common"


### PR DESCRIPTION
## 설명
- [#13] 어플리케이션 설정 파일 환경별로 분리

## 작업 내용
- 설정파일을 스프링부트 프로파일을 이용하여 `local` 환경과 `prod`환경으로 분리하였고, 공통으로 적용되는 파일을 지정하였습니다.
