### PR TITLE
[#17] Party 가입 요청 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok'
+
+    annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/flab/weshare/domain/base/BaseResponse.java
+++ b/src/main/java/com/flab/weshare/domain/base/BaseResponse.java
@@ -1,5 +1,7 @@
 package com.flab.weshare.domain.base;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.Builder;
@@ -9,6 +11,8 @@ import lombok.Getter;
 @Builder
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class BaseResponse<T> {
+	private static final String COMMON_CREATED_ID = "id";
+
 	private boolean success;
 	private T data;
 	private ErrorResponse errorResponse;
@@ -30,6 +34,13 @@ public class BaseResponse<T> {
 		return BaseResponse.builder()
 			.success(false)
 			.errorResponse(errorResponse)
+			.build();
+	}
+
+	public static <T> BaseResponse created(T generatedPartyId) {
+		return BaseResponse.builder()
+			.success(true)
+			.data(Map.of(COMMON_CREATED_ID, generatedPartyId))
 			.build();
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.flab.weshare.domain.base.BaseResponse;
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.service.PartyService;
 import com.flab.weshare.utils.jwt.JwtAuthentication;
 
@@ -45,5 +46,15 @@ public class PartyController {
 		partyService.updatePartyDetails(modifyPartyRequest, partyId);
 
 		return BaseResponse.success();
+	}
+
+	@PostMapping("/join")
+	@ResponseStatus(HttpStatus.CREATED)
+	public BaseResponse createPartyRequest(@RequestBody @Valid final PartyJoinRequest partyJoinRequest,
+		@AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
+
+		Long generatedPartyJoinId = partyService.generatePartyJoin(partyJoinRequest, jwtAuthentication.getId());
+
+		return BaseResponse.created(generatedPartyJoinId);
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -1,0 +1,49 @@
+package com.flab.weshare.domain.party.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.weshare.domain.base.BaseResponse;
+import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.service.PartyService;
+import com.flab.weshare.utils.jwt.JwtAuthentication;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/party")
+public class PartyController {
+	private final PartyService partyService;
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public BaseResponse createParty(@RequestBody @Valid PartyCreationRequest partyCreationRequest,
+		@AuthenticationPrincipal JwtAuthentication jwtAuthentication) {
+
+		Long generatedPartyId = partyService.generateParty(partyCreationRequest, jwtAuthentication.getId());
+
+		return BaseResponse.created(generatedPartyId);
+	}
+
+	@PutMapping("/{partyId}")
+	@ResponseStatus(HttpStatus.OK)
+	public BaseResponse patchPartyCapacity(@PathVariable Long partyId
+		, @RequestBody @Valid ModifyPartyRequest modifyPartyRequest) {
+
+		partyService.updatePartyDetails(partyId, modifyPartyRequest);
+
+		return BaseResponse.success();
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -29,8 +29,8 @@ public class PartyController {
 
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
-	public BaseResponse createParty(@RequestBody @Valid PartyCreationRequest partyCreationRequest,
-		@AuthenticationPrincipal JwtAuthentication jwtAuthentication) {
+	public BaseResponse createParty(@RequestBody @Valid final PartyCreationRequest partyCreationRequest,
+		@AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
 
 		Long generatedPartyId = partyService.generateParty(partyCreationRequest, jwtAuthentication.getId());
 
@@ -39,8 +39,8 @@ public class PartyController {
 
 	@PutMapping("/{partyId}")
 	@ResponseStatus(HttpStatus.OK)
-	public BaseResponse patchPartyCapacity(@PathVariable Long partyId
-		, @RequestBody @Valid ModifyPartyRequest modifyPartyRequest) {
+	public BaseResponse patchPartyCapacity(@PathVariable final Long partyId
+		, @RequestBody @Valid final ModifyPartyRequest modifyPartyRequest) {
 
 		partyService.updatePartyDetails(partyId, modifyPartyRequest);
 

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -42,7 +42,7 @@ public class PartyController {
 	public BaseResponse patchPartyCapacity(@PathVariable final Long partyId
 		, @RequestBody @Valid final ModifyPartyRequest modifyPartyRequest) {
 
-		partyService.updatePartyDetails(partyId, modifyPartyRequest);
+		partyService.updatePartyDetails(modifyPartyRequest, partyId);
 
 		return BaseResponse.success();
 	}

--- a/src/main/java/com/flab/weshare/domain/party/dto/ModifyPartyRequest.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/ModifyPartyRequest.java
@@ -1,0 +1,7 @@
+package com.flab.weshare.domain.party.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ModifyPartyRequest(@NotNull int capacity,
+								 @NotNull String password) {
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/PartyCreationRequest.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/PartyCreationRequest.java
@@ -1,0 +1,10 @@
+package com.flab.weshare.domain.party.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PartyCreationRequest(@NotNull Long ottId,
+								   @NotNull String ottAccountId,
+								   @NotNull String ottAccountPassword,
+								   @NotNull int capacity) {
+
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/PartyJoinRequest.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/PartyJoinRequest.java
@@ -1,0 +1,9 @@
+package com.flab.weshare.domain.party.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Party 요청
+ */
+public record PartyJoinRequest(@NotNull Long ottId) {
+}

--- a/src/main/java/com/flab/weshare/domain/party/entity/Ott.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Ott.java
@@ -4,14 +4,21 @@ import org.hibernate.annotations.Immutable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Immutable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Ott {
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "ott_id")
 	private Long id;
 	private String name;
@@ -19,6 +26,15 @@ public class Ott {
 	private int leaderFee;
 	private int maximumCapacity;
 	private int minimumCapacity;
+
+	@Builder
+	private Ott(String name, int commonFee, int leaderFee, int maximumCapacity, int minimumCapacity) {
+		this.name = name;
+		this.commonFee = commonFee;
+		this.leaderFee = leaderFee;
+		this.maximumCapacity = maximumCapacity;
+		this.minimumCapacity = minimumCapacity;
+	}
 
 	public boolean isValidCapacity(int capacity) {
 		return capacity >= minimumCapacity && capacity <= maximumCapacity;

--- a/src/main/java/com/flab/weshare/domain/party/entity/Party.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Party.java
@@ -73,8 +73,6 @@ public class Party extends BaseEntity {
 	}
 
 	public boolean isChangeableCapacity(int capacity) {
-		System.out.println(capacity);
-		System.out.println(this.partyMembers.size());
 		return this.partyMembers.size() <= capacity - 1;
 	}
 

--- a/src/main/java/com/flab/weshare/domain/party/entity/Party.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Party.java
@@ -3,6 +3,8 @@ package com.flab.weshare.domain.party.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.flab.weshare.domain.base.BaseEntity;
 import com.flab.weshare.domain.user.entity.User;
 
@@ -24,6 +26,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 @Getter
 public class Party extends BaseEntity {
 	@Id
@@ -52,7 +55,7 @@ public class Party extends BaseEntity {
 	@Column(nullable = false)
 	private PartyStatus partyStatus;
 
-	@OneToMany(mappedBy = "partyMember")
+	@OneToMany(mappedBy = "party")
 	private List<PartyMember> partyMembers = new ArrayList<>();
 
 	@Builder
@@ -63,5 +66,19 @@ public class Party extends BaseEntity {
 		this.ottAccountPassword = ottAccountPassword;
 		this.capacity = capacity;
 		this.partyStatus = PartyStatus.RUNNING;
+	}
+
+	public void changeCapacity(int capacity) {
+		this.capacity = capacity;
+	}
+
+	public boolean isChangeableCapacity(int capacity) {
+		System.out.println(capacity);
+		System.out.println(this.partyMembers.size());
+		return this.partyMembers.size() <= capacity - 1;
+	}
+
+	public void changePassword(String encodedPassword) {
+		this.ottAccountPassword = encodedPassword;
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
@@ -39,7 +39,7 @@ public class PartyJoin extends BaseEntity {
 	private PartyJoinStatus partyJoinStatus;
 
 	@Builder
-	private PartyJoin(User user, Ott ott, PartyJoinStatus partyJoinStatus) {
+	private PartyJoin(User user, Ott ott) {
 		this.user = user;
 		this.ott = ott;
 		this.partyJoinStatus = PartyJoinStatus.WAITING;

--- a/src/main/java/com/flab/weshare/domain/party/repository/OttRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/OttRepository.java
@@ -1,0 +1,8 @@
+package com.flab.weshare.domain.party.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flab.weshare.domain.party.entity.Ott;
+
+public interface OttRepository extends JpaRepository<Ott, Long> {
+}

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
@@ -1,0 +1,8 @@
+package com.flab.weshare.domain.party.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flab.weshare.domain.party.entity.PartyJoin;
+
+public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
+}

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
@@ -1,0 +1,15 @@
+package com.flab.weshare.domain.party.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.flab.weshare.domain.party.entity.Party;
+
+public interface PartyRepository extends JpaRepository<Party, Long> {
+
+	@Query("select p from Party p left join fetch p.partyMembers join fetch p.ott where p.id =:partyId")
+	Optional<Party> findFetchByPartyId(@Param("partyId") Long partyId);
+}

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -47,7 +47,7 @@ public class PartyService {
 		return generateParty.getId();
 	}
 
-	private void validateCapacity(Ott requestOtt, int capacity) {
+	private void validateCapacity(final Ott requestOtt, final int capacity) {
 		if (!requestOtt.isValidCapacity(capacity)) {
 			throw new CommonClientException(ErrorCode.INVALID_CAPACITY);
 		}
@@ -66,7 +66,7 @@ public class PartyService {
 		party.changePassword(encodedPassword);
 	}
 
-	private void validateChangeableCapacity(Party party, ModifyPartyRequest modifyPartyRequest) {
+	private void validateChangeableCapacity(final Party party, final ModifyPartyRequest modifyPartyRequest) {
 		if (!party.isChangeableCapacity(modifyPartyRequest.capacity())) {
 
 			throw new CommonClientException(ErrorCode.INSUFFICIENT_CAPACITY);

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -29,11 +29,11 @@ public class PartyService {
 	public Long generateParty(final PartyCreationRequest partyCreationRequest, final Long requestPartyLeaderId) {
 		Ott requestOtt = ottRepository.findById(partyCreationRequest.ottId())
 			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("ott")));
-		User requestPartyLeader = userRepository.getReferenceById(requestPartyLeaderId);
-		String encodedPassword = passwordEncoder.encode(partyCreationRequest.ottAccountPassword());
 
 		validateCapacity(requestOtt, partyCreationRequest.capacity());
 
+		User requestPartyLeader = userRepository.getReferenceById(requestPartyLeaderId);
+		String encodedPassword = passwordEncoder.encode(partyCreationRequest.ottAccountPassword());
 		Party generateParty = Party.builder()
 			.ott(requestOtt)
 			.leader(requestPartyLeader)
@@ -57,10 +57,11 @@ public class PartyService {
 	public void updatePartyDetails(final Long partyId, final ModifyPartyRequest modifyPartyRequest) {
 		Party party = partyRepository.findFetchByPartyId(partyId)
 			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("party")));
-		String encodedPassword = passwordEncoder.encode(modifyPartyRequest.password());
 
 		validateCapacity(party.getOtt(), modifyPartyRequest.capacity());
 		validateChangeableCapacity(party, modifyPartyRequest);
+
+		String encodedPassword = passwordEncoder.encode(modifyPartyRequest.password());
 
 		party.changeCapacity(modifyPartyRequest.capacity());
 		party.changePassword(encodedPassword);

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -1,0 +1,75 @@
+package com.flab.weshare.domain.party.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.entity.Ott;
+import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.party.repository.PartyRepository;
+import com.flab.weshare.domain.user.entity.User;
+import com.flab.weshare.domain.user.repository.UserRepository;
+import com.flab.weshare.exception.ErrorCode;
+import com.flab.weshare.exception.exceptions.CommonClientException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PartyService {
+	private final PartyRepository partyRepository;
+	private final OttRepository ottRepository;
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	public Long generateParty(final PartyCreationRequest partyCreationRequest, final Long requestPartyLeaderId) {
+		Ott requestOtt = ottRepository.findById(partyCreationRequest.ottId())
+			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("ott")));
+		User requestPartyLeader = userRepository.getReferenceById(requestPartyLeaderId);
+		String encodedPassword = passwordEncoder.encode(partyCreationRequest.ottAccountPassword());
+
+		validateCapacity(requestOtt, partyCreationRequest.capacity());
+
+		Party generateParty = Party.builder()
+			.ott(requestOtt)
+			.leader(requestPartyLeader)
+			.capacity(partyCreationRequest.capacity())
+			.ottAccountId(partyCreationRequest.ottAccountId())
+			.ottAccountPassword(encodedPassword)
+			.build();
+
+		partyRepository.save(generateParty);
+
+		return generateParty.getId();
+	}
+
+	private void validateCapacity(Ott requestOtt, int capacity) {
+		if (!requestOtt.isValidCapacity(capacity)) {
+			throw new CommonClientException(ErrorCode.INVALID_CAPACITY);
+		}
+	}
+
+	@Transactional
+	public void updatePartyDetails(final Long partyId, final ModifyPartyRequest modifyPartyRequest) {
+		Party party = partyRepository.findFetchByPartyId(partyId)
+			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("party")));
+		String encodedPassword = passwordEncoder.encode(modifyPartyRequest.password());
+
+		validateCapacity(party.getOtt(), modifyPartyRequest.capacity());
+		validateChangeableCapacity(party, modifyPartyRequest);
+
+		party.changeCapacity(modifyPartyRequest.capacity());
+		party.changePassword(encodedPassword);
+	}
+
+	private void validateChangeableCapacity(Party party, ModifyPartyRequest modifyPartyRequest) {
+		if (!party.isChangeableCapacity(modifyPartyRequest.capacity())) {
+
+			throw new CommonClientException(ErrorCode.INSUFFICIENT_CAPACITY);
+		}
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -6,9 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.entity.PartyJoin;
 import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.party.repository.PartyJoinRepository;
 import com.flab.weshare.domain.party.repository.PartyRepository;
 import com.flab.weshare.domain.user.entity.User;
 import com.flab.weshare.domain.user.repository.UserRepository;
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PartyService {
 	private final PartyRepository partyRepository;
+	private final PartyJoinRepository partyJoinRepository;
 	private final OttRepository ottRepository;
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
@@ -72,5 +76,20 @@ public class PartyService {
 
 			throw new CommonClientException(ErrorCode.INSUFFICIENT_CAPACITY);
 		}
+	}
+
+	@Transactional
+	public Long generatePartyJoin(final PartyJoinRequest PartyJoinRequest, final Long userId) {
+		User partyParticipant = userRepository.getReferenceById(userId);
+		Ott selectedOtt = ottRepository.getReferenceById(PartyJoinRequest.ottId());
+
+		PartyJoin partyJoin = PartyJoin.builder()
+			.ott(selectedOtt)
+			.user(partyParticipant)
+			.build();
+
+		partyJoinRepository.save(partyJoin);
+
+		return partyJoin.getId();
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -54,7 +54,7 @@ public class PartyService {
 	}
 
 	@Transactional
-	public void updatePartyDetails(final Long partyId, final ModifyPartyRequest modifyPartyRequest) {
+	public void updatePartyDetails(final ModifyPartyRequest modifyPartyRequest, final Long partyId) {
 		Party party = partyRepository.findFetchByPartyId(partyId)
 			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("party")));
 

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -19,7 +19,9 @@ public class ErrorCode {
 	public static final ErrorCode INVALID_CAPACITY = new ErrorCode("INVALID_CAPACITY", "파티의 정원수가 잘못되었습니다.");
 	public static final ErrorCode INSUFFICIENT_CAPACITY = new ErrorCode("INSUFFICIENT_CAPACITY",
 		"현재 파티인원보다 작을 수 없습니다.");
-	private static final ErrorCode RESOURCE_NOT_FOUND = new ErrorCode("RESOURCE_NOT_FOUND", " 리소스를 찾을 수 없습니다.");
+	public static final ErrorCode RESOURCE_NOT_FOUND = new ErrorCode("RESOURCE_NOT_FOUND", "리소스를 찾을 수 없습니다.");
+	public static final ErrorCode DATA_INTEGRITY_VIOLATION = new ErrorCode("DATA_INTEGRITY_VIOLATION",
+		"DB 오류가 발생했습니다.");
 
 	private final String errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -3,25 +3,56 @@ package com.flab.weshare.exception;
 import lombok.Getter;
 
 @Getter
-public enum ErrorCode {
-	INTRENAL_SERVER_ERROR("internal_server_error", "서버에 에러가 발생했습니다."),
-	DUPLICATE_EMAIL("duplicate_email", "이미 존재하는 이메일입니다."),
-	DUPLICATE_NICKNAME("duplicate_nickname", "이미 존재하는 닉네임입니다."),
-	INVALID_INPUT("invalid_input", "입력값이 올바르지 않습니다."),
-	USER_NOT_FOUND("user_not_found", "입력한 로그인 정보에 해당하는 유저가 없습니다."),
-	INVALID_ID("INVALID_ID", "ID에 해당하는 유저가 없습니다."),
-	WRONG_PASSWORD("WRONG_PASSWORD", "비밀번호가 일치하지 않습니다."),
-	ALREADY_LOGGED_OUT("ALREADY_LOGGEND_OUT", "이미 로그아웃한 상태입니다."),
-	MALFORMED_JWT("MALFORMED_JWT", "잘못된 JWT 서명입니다."),
-	EXPIRED_JWT("EXPIRED_JWT", "만료된 JWT 토큰입니다."),
-	UNSUPPORTED_JWT("UNSUPPORTED_JWT", "지원되지 않는 JWT 토큰입니다."),
-	ILLEGAL_JWT("ILLEGAL_JWT", "JWT 토큰이 잘못되었습니다.");
+public class ErrorCode {
+	public static final ErrorCode INTRENAL_SERVER_ERROR = new ErrorCode("internal_server_error", "서버에 에러가 발생했습니다.");
+	public static final ErrorCode DUPLICATE_EMAIL = new ErrorCode("duplicate_email", "이미 존재하는 이메일입니다.");
+	public static final ErrorCode DUPLICATE_NICKNAME = new ErrorCode("duplicate_nickname", "이미 존재하는 닉네임입니다.");
+	public static final ErrorCode INVALID_INPUT = new ErrorCode("invalid_input", "입력값이 올바르지 않습니다.");
+	public static final ErrorCode USER_NOT_FOUND = new ErrorCode("user_not_found", "입력한 로그인 정보에 해당하는 유저가 없습니다.");
+	public static final ErrorCode INVALID_ID = new ErrorCode("INVALID_ID", "ID에 해당하는 유저가 없습니다.");
+	public static final ErrorCode WRONG_PASSWORD = new ErrorCode("WRONG_PASSWORD", "비밀번호가 일치하지 않습니다.");
+	public static final ErrorCode ALREADY_LOGGED_OUT = new ErrorCode("ALREADY_LOGGEND_OUT", "이미 로그아웃한 상태입니다.");
+	public static final ErrorCode MALFORMED_JWT = new ErrorCode("MALFORMED_JWT", "잘못된 JWT 서명입니다.");
+	public static final ErrorCode EXPIRED_JWT = new ErrorCode("EXPIRED_JWT", "만료된 JWT 토큰입니다.");
+	public static final ErrorCode UNSUPPORTED_JWT = new ErrorCode("UNSUPPORTED_JWT", "지원되지 않는 JWT 토큰입니다.");
+	public static final ErrorCode ILLEGAL_JWT = new ErrorCode("ILLEGAL_JWT", "JWT 토큰이 잘못되었습니다.");
+	public static final ErrorCode INVALID_CAPACITY = new ErrorCode("INVALID_CAPACITY", "파티의 정원수가 잘못되었습니다.");
+	public static final ErrorCode INSUFFICIENT_CAPACITY = new ErrorCode("INSUFFICIENT_CAPACITY",
+		"현재 파티인원보다 작을 수 없습니다.");
+	private static final ErrorCode RESOURCE_NOT_FOUND = new ErrorCode("RESOURCE_NOT_FOUND", " 리소스를 찾을 수 없습니다.");
 
 	private final String errorCode;
 	private final String errorMessage;
 
-	ErrorCode(String errorCode, String errorMessage) {
+	public ErrorCode(String errorCode, String errorMessage) {
 		this.errorCode = errorCode;
 		this.errorMessage = errorMessage;
+	}
+
+	public static ErrorCode makeSpecificResourceNotFoundErrorCode(String resourceName) {
+		return new ErrorCode(RESOURCE_NOT_FOUND.errorCode, resourceName + RESOURCE_NOT_FOUND.errorMessage);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		ErrorCode errorCode1 = (ErrorCode)o;
+
+		if (getErrorCode() != null ? !getErrorCode().equals(errorCode1.getErrorCode()) :
+			errorCode1.getErrorCode() != null)
+			return false;
+		return getErrorMessage() != null ? getErrorMessage().equals(errorCode1.getErrorMessage()) :
+			errorCode1.getErrorMessage() == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getErrorCode() != null ? getErrorCode().hashCode() : 0;
+		result = 31 * result + (getErrorMessage() != null ? getErrorMessage().hashCode() : 0);
+		return result;
 	}
 }

--- a/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
+++ b/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.flab.weshare.exception.advice;
 
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,6 +26,13 @@ public class ControllerAdvice {
 		return BaseResponse.fail(ErrorResponse.of(ErrorCode.INTRENAL_SERVER_ERROR));
 	}
 
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public BaseResponse commonExceptionHandler(DataIntegrityViolationException dataIntegrityViolationException) {
+		log.error("exception :", dataIntegrityViolationException);
+		return BaseResponse.fail(ErrorResponse.of(ErrorCode.DATA_INTEGRITY_VIOLATION));
+	}
+
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(CommonClientException.class)
 	public BaseResponse commonExceptionHandler(CommonClientException commonClientException) {
@@ -39,7 +47,7 @@ public class ControllerAdvice {
 		return BaseResponse.fail(ErrorResponse.of(ErrorCode.INVALID_INPUT, extractFieldErrors(bindException)));
 	}
 
-	private List<ErrorResponse.FieldError> extractFieldErrors (BindException bindException){
+	private List<ErrorResponse.FieldError> extractFieldErrors(BindException bindException) {
 		return bindException.getBindingResult()
 			.getFieldErrors()
 			.stream()

--- a/src/test/java/com/flab/weshare/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/auth/controller/AuthControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import com.flab.weshare.domain.auth.dto.LoginRequest;
 import com.flab.weshare.domain.base.BaseControllerTest;
 import com.flab.weshare.exception.ErrorCode;
+import com.flab.weshare.utils.jwt.JwtProperties;
 
 public class AuthControllerTest extends BaseControllerTest {
 	LoginRequest rightloginRequest = new LoginRequest(EMAIL, PASSWORD);
@@ -44,7 +45,7 @@ public class AuthControllerTest extends BaseControllerTest {
 	@Test
 	void logout_success() throws Exception {
 		mockMvc.perform(post("/api/logout")
-				.header("Authorization", "Bearer " + REFRESH_TOKEN))
+				.header(JwtProperties.HEADER, REFRESH_TOKEN))
 			.andExpect(status().isOk());
 	}
 
@@ -59,7 +60,7 @@ public class AuthControllerTest extends BaseControllerTest {
 	@Test
 	void reIssue_success() throws Exception {
 		mockMvc.perform(post("/api/reissue")
-				.header("Authorization", "Bearer " + REFRESH_TOKEN))
+				.header(JwtProperties.HEADER, REFRESH_TOKEN))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.accessToken").exists())
 			.andExpect(jsonPath("$.data.refreshToken").exists());

--- a/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
@@ -64,16 +64,39 @@ public abstract class BaseControllerTest {
 
 	@BeforeEach
 	void setUpLogin() {
-		saveEntities();
+		userRepository.save(savedUser);
 		ACCESS_TOKEN = JwtProperties.TOKEN_PREFIX + jwtUtil.createAccessToken(savedUser.getId());
 		REFRESH_TOKEN = JwtProperties.TOKEN_PREFIX + jwtUtil.createRefreshToken(savedUser.getId());
 	}
 
-	private void saveEntities() {
-		userRepository.save(savedUser);
+	@BeforeEach
+	void saveEntities() {
 		ottRepository.save(savedOtt);
 		partyRepository.save(savedParty);
 
+		List<User> users = createUsers();
+		userRepository.saveAll(users);
+
+		List<PartyMember> partyMembers = createPartyMembers(users);
+		partyMemberRepository.saveAll(partyMembers);
+
+		entityManager.clear();
+	}
+
+	private List<PartyMember> createPartyMembers(List<User> users) {
+		List<PartyMember> partyMembers = new ArrayList<>();
+		for (int i = 0; i < 2; i++) {
+			PartyMember partyMember = PartyMember.builder()
+				.party(savedParty)
+				.partyMember(users.get(i))
+				.partyMemberStatus(PartyMemberStatus.ATTENDING)
+				.build();
+			partyMembers.add(partyMember);
+		}
+		return partyMembers;
+	}
+
+	private List<User> createUsers() {
 		List<User> members = new ArrayList<>();
 		for (int i = 0; i < 2; i++) {
 			User build = User.builder()
@@ -85,17 +108,6 @@ public abstract class BaseControllerTest {
 				.build();
 			members.add(build);
 		}
-		userRepository.saveAll(members);
-
-		for (int i = 0; i < 2; i++) {
-			PartyMember build = PartyMember.builder()
-				.party(savedParty)
-				.partyMember(members.get(i))
-				.partyMemberStatus(PartyMemberStatus.ATTENDING)
-				.build();
-			partyMemberRepository.save(build);
-		}
-
-		entityManager.clear();
+		return members;
 	}
 }

--- a/src/test/java/com/flab/weshare/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/controller/PartyControllerTest.java
@@ -1,0 +1,75 @@
+package com.flab.weshare.domain.party.controller;
+
+import static com.flab.weshare.domain.utils.TestUtil.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.flab.weshare.domain.base.BaseControllerTest;
+import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.exception.ErrorCode;
+import com.flab.weshare.utils.jwt.JwtProperties;
+
+class PartyControllerTest extends BaseControllerTest {
+	@DisplayName("파티를 생성할 수 있다.")
+	@Test
+	void success_party_creation() throws Exception {
+		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
+			savedOtt.getId(), OTT_ACCOUNT_ID, OTT_PASSWORD, PARTY_MAXIMUM_CAPACITY);
+
+		mockMvc.perform(post("/api/v1/party")
+				.header(JwtProperties.HEADER, ACCESS_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(partyCreationRequest)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.success").value("true"))
+			.andExpect(jsonPath("$.data.id").exists());
+	}
+
+	@DisplayName("파티의 정원이 요청한 Ott의 최대정원보다 높을시 실패한다.")
+	@Test
+	void fail_party_creation() throws Exception {
+		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
+			savedOtt.getId(), OTT_ACCOUNT_ID, OTT_PASSWORD, MAXIMUM_CAPACITY + 2);
+
+		mockMvc.perform(post("/api/v1/party")
+				.header(JwtProperties.HEADER, ACCESS_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(partyCreationRequest)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value("false"))
+			.andExpect(jsonPath("$.errorResponse.errorCode").value(ErrorCode.INVALID_CAPACITY.getErrorCode()))
+			.andExpect(jsonPath("$.errorResponse.errorMessage").value(ErrorCode.INVALID_CAPACITY.getErrorMessage()));
+	}
+
+	@DisplayName("파티의 비밀번호와 정원을 수정할 수 있다.")
+	@Test
+	void successPartyUpdate() throws Exception {
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(4, "asddff222");
+
+		mockMvc.perform(put("/api/v1/party/" + savedParty.getId())
+				.header(JwtProperties.HEADER, ACCESS_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(modifyPartyRequest)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value("true"));
+	}
+
+	@DisplayName("현재 파티의 인원수보다 적게 정원수를 변경할 수 없다.")
+	@Test
+	void failPartyUpdate() throws Exception {
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(2, "asddff222");
+		mockMvc.perform(put("/api/v1/party/" + savedParty.getId())
+				.header(JwtProperties.HEADER, ACCESS_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(modifyPartyRequest)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorResponse.errorCode").value(ErrorCode.INSUFFICIENT_CAPACITY.getErrorCode()))
+			.andExpect(
+				jsonPath("$.errorResponse.errorMessage").value(ErrorCode.INSUFFICIENT_CAPACITY.getErrorMessage()));
+	}
+}

--- a/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
@@ -1,0 +1,124 @@
+package com.flab.weshare.domain.party.service;
+
+import static com.flab.weshare.domain.utils.TestUtil.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.party.repository.PartyRepository;
+import com.flab.weshare.domain.user.repository.UserRepository;
+import com.flab.weshare.exception.ErrorCode;
+import com.flab.weshare.exception.exceptions.CommonClientException;
+
+@ExtendWith(MockitoExtension.class)
+class PartyServiceTest {
+	@InjectMocks
+	PartyService partyService;
+
+	@Mock
+	PartyRepository partyRepository;
+
+	@Mock
+	OttRepository ottRepository;
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@Mock
+	private Party mockParty;
+
+	@DisplayName("유효한 파티 생성 요청일 시 데이터베이스에 저장.")
+	@Test
+	void generate_party_sucesss() {
+		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
+			1L, OTT_ACCOUNT_ID, OTT_PASSWORD, PARTY_MAXIMUM_CAPACITY);
+
+		given(ottRepository.findById(anyLong())).willReturn(Optional.of(savedOtt));
+		given(userRepository.getReferenceById(anyLong())).willReturn(savedUser);
+
+		ReflectionTestUtils.setField(savedOtt, "id", 1L);
+		ReflectionTestUtils.setField(savedUser, "id", 1L);
+
+		partyService.generateParty(partyCreationRequest, savedUser.getId());
+
+		then(partyRepository).should(times(1)).save(any(Party.class));
+	}
+
+	@DisplayName("생성하려는 파티의 ott를 찾을 수 없는경우 예외를 반환")
+	@Test
+	void generate_party_fail_not_found_ott() {
+		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
+			1L, OTT_ACCOUNT_ID, OTT_PASSWORD, PARTY_MAXIMUM_CAPACITY);
+
+		given(ottRepository.findById(anyLong())).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> partyService.generateParty(partyCreationRequest, 1L))
+			.isInstanceOf(CommonClientException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.makeSpecificResourceNotFoundErrorCode("ott"));
+	}
+
+	@DisplayName("파티의 정원이 올바르지않을 경우 예외를 반환")
+	@Test
+	void generate_party_fail_invalid_capacity() {
+		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
+			1L, OTT_ACCOUNT_ID, OTT_PASSWORD, MAXIMUM_CAPACITY + 1);
+
+		given(ottRepository.findById(anyLong())).willReturn(Optional.of(savedOtt));
+		given(userRepository.getReferenceById(anyLong())).willReturn(savedUser);
+
+		ReflectionTestUtils.setField(savedOtt, "id", 1L);
+		ReflectionTestUtils.setField(savedUser, "id", 1L);
+
+		assertThatThrownBy(() -> partyService.generateParty(partyCreationRequest, 1L))
+			.isInstanceOf(CommonClientException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_CAPACITY);
+	}
+
+	@DisplayName("유효한 파티 수정요청일 경우 파티의 상태를 업데이트한다.")
+	@Test
+	void update_party_success() {
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(3, PASSWORD);
+
+		given(partyRepository.findFetchByPartyId(anyLong())).willReturn(Optional.of(mockParty));
+		given(mockParty.getOtt()).willReturn(savedOtt);
+		given(mockParty.isChangeableCapacity(anyInt())).willReturn(true);
+
+		partyService.updatePartyDetails(1L, modifyPartyRequest);
+		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
+		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
+	}
+
+	@DisplayName("현재 파티 인원보다 적게 변경하는 요청시 예외를 반환")
+	@Test
+	void update_party_fail() {
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(3, PASSWORD);
+
+		given(partyRepository.findFetchByPartyId(anyLong())).willReturn(Optional.of(mockParty));
+		given(mockParty.getOtt()).willReturn(savedOtt);
+		given(mockParty.isChangeableCapacity(anyInt())).willReturn(false);
+
+		assertThatThrownBy(() -> partyService.updatePartyDetails(1L, modifyPartyRequest))
+			.isInstanceOf(CommonClientException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INSUFFICIENT_CAPACITY);
+	}
+}

--- a/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
@@ -102,7 +102,7 @@ class PartyServiceTest {
 		given(mockParty.getOtt()).willReturn(savedOtt);
 		given(mockParty.isChangeableCapacity(anyInt())).willReturn(true);
 
-		partyService.updatePartyDetails(1L, modifyPartyRequest);
+		partyService.updatePartyDetails(modifyPartyRequest, 1L);
 		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
 		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
 	}
@@ -116,7 +116,7 @@ class PartyServiceTest {
 		given(mockParty.getOtt()).willReturn(savedOtt);
 		given(mockParty.isChangeableCapacity(anyInt())).willReturn(false);
 
-		assertThatThrownBy(() -> partyService.updatePartyDetails(1L, modifyPartyRequest))
+		assertThatThrownBy(() -> partyService.updatePartyDetails(modifyPartyRequest, 1L))
 			.isInstanceOf(CommonClientException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.INSUFFICIENT_CAPACITY);

--- a/src/test/java/com/flab/weshare/domain/utils/TestUtil.java
+++ b/src/test/java/com/flab/weshare/domain/utils/TestUtil.java
@@ -2,6 +2,8 @@ package com.flab.weshare.domain.utils;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import com.flab.weshare.domain.party.entity.Ott;
+import com.flab.weshare.domain.party.entity.Party;
 import com.flab.weshare.domain.user.entity.User;
 
 public class TestUtil {
@@ -19,5 +21,35 @@ public class TestUtil {
 		.password(bCryptPasswordEncoder.encode(PASSWORD))
 		.nickName(NICKNAME)
 		.telephone(TELEPHONE)
+		.build();
+
+	//Ott
+	public static final Long OTT_ID = 1L;
+	public static final String OTT_NAME = "WEFLIX";
+	public static final int COMMON_FEE = 3000;
+	public static final int LEADER_FEE = 2500;
+	public static final int MAXIMUM_CAPACITY = 4;
+	public static final int MINIMUM_CAPACITY = 1;
+	public static final Ott savedOtt = Ott
+		.builder()
+		.name(OTT_NAME)
+		.leaderFee(LEADER_FEE)
+		.commonFee(COMMON_FEE)
+		.maximumCapacity(MAXIMUM_CAPACITY)
+		.minimumCapacity(MINIMUM_CAPACITY)
+		.build();
+
+	//Party
+	public static final Long PARTY_ID = 1L;
+	public static final int PARTY_MAXIMUM_CAPACITY = 3;
+	public static final String OTT_ACCOUNT_ID = "test123";
+	public static final String OTT_PASSWORD = "test1234!";
+	public static final Party savedParty = Party
+		.builder()
+		.leader(savedUser)
+		.ott(savedOtt)
+		.capacity(PARTY_MAXIMUM_CAPACITY)
+		.ottAccountId(OTT_ACCOUNT_ID)
+		.ottAccountPassword(OTT_PASSWORD)
 		.build();
 }


### PR DESCRIPTION
## 설명
- [#17] Party 가입 요청 api 구현

## 작업 내용
- Party 가입 요청 api 구현
- Spring Data Jpa에서 제약 조건 위반을 핸들하는 `DataIntegrityException`을 `ControllerAdvice`에서 일괄처리

Party 요청이 들어오면 `PartyJoin`테이블에 저장하여 일시적으로 대기 시킨 후 배치작업으로 파티 매칭을 하는 방향을 생각중입니다.