### PR TITLE
[#17] Party 가입 요청 api 구현 

### DIFF
--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.flab.weshare.domain.base.BaseResponse;
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.service.PartyService;
 import com.flab.weshare.utils.jwt.JwtAuthentication;
 
@@ -45,5 +46,15 @@ public class PartyController {
 		partyService.updatePartyDetails(modifyPartyRequest, partyId);
 
 		return BaseResponse.success();
+	}
+
+	@PostMapping("/join")
+	@ResponseStatus(HttpStatus.CREATED)
+	public BaseResponse createPartyRequest(@RequestBody @Valid final PartyJoinRequest partyJoinRequest,
+		@AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
+
+		Long generatedPartyJoinId = partyService.generatePartyJoin(partyJoinRequest, jwtAuthentication.getId());
+
+		return BaseResponse.created(generatedPartyJoinId);
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -42,7 +42,7 @@ public class PartyController {
 	public BaseResponse patchPartyCapacity(@PathVariable final Long partyId
 		, @RequestBody @Valid final ModifyPartyRequest modifyPartyRequest) {
 
-		partyService.updatePartyDetails(partyId, modifyPartyRequest);
+		partyService.updatePartyDetails(modifyPartyRequest, partyId);
 
 		return BaseResponse.success();
 	}

--- a/src/main/java/com/flab/weshare/domain/party/dto/PartyJoinRequest.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/PartyJoinRequest.java
@@ -1,0 +1,9 @@
+package com.flab.weshare.domain.party.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Party 요청
+ */
+public record PartyJoinRequest(@NotNull Long ottId) {
+}

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
@@ -39,7 +39,7 @@ public class PartyJoin extends BaseEntity {
 	private PartyJoinStatus partyJoinStatus;
 
 	@Builder
-	private PartyJoin(User user, Ott ott, PartyJoinStatus partyJoinStatus) {
+	private PartyJoin(User user, Ott ott) {
 		this.user = user;
 		this.ott = ott;
 		this.partyJoinStatus = PartyJoinStatus.WAITING;

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
@@ -1,0 +1,8 @@
+package com.flab.weshare.domain.party.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flab.weshare.domain.party.entity.PartyJoin;
+
+public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
+}

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -6,9 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.entity.PartyJoin;
 import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.party.repository.PartyJoinRepository;
 import com.flab.weshare.domain.party.repository.PartyRepository;
 import com.flab.weshare.domain.user.entity.User;
 import com.flab.weshare.domain.user.repository.UserRepository;
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PartyService {
 	private final PartyRepository partyRepository;
+	private final PartyJoinRepository partyJoinRepository;
 	private final OttRepository ottRepository;
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
@@ -72,5 +76,20 @@ public class PartyService {
 
 			throw new CommonClientException(ErrorCode.INSUFFICIENT_CAPACITY);
 		}
+	}
+
+	@Transactional
+	public Long generatePartyJoin(final PartyJoinRequest PartyJoinRequest, final Long userId) {
+		User partyParticipant = userRepository.getReferenceById(userId);
+		Ott selectedOtt = ottRepository.getReferenceById(PartyJoinRequest.ottId());
+
+		PartyJoin partyJoin = PartyJoin.builder()
+			.ott(selectedOtt)
+			.user(partyParticipant)
+			.build();
+
+		partyJoinRepository.save(partyJoin);
+
+		return partyJoin.getId();
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -54,7 +54,7 @@ public class PartyService {
 	}
 
 	@Transactional
-	public void updatePartyDetails(final Long partyId, final ModifyPartyRequest modifyPartyRequest) {
+	public void updatePartyDetails(final ModifyPartyRequest modifyPartyRequest, final Long partyId) {
 		Party party = partyRepository.findFetchByPartyId(partyId)
 			.orElseThrow(() -> new CommonClientException(ErrorCode.makeSpecificResourceNotFoundErrorCode("party")));
 

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -19,7 +19,9 @@ public class ErrorCode {
 	public static final ErrorCode INVALID_CAPACITY = new ErrorCode("INVALID_CAPACITY", "파티의 정원수가 잘못되었습니다.");
 	public static final ErrorCode INSUFFICIENT_CAPACITY = new ErrorCode("INSUFFICIENT_CAPACITY",
 		"현재 파티인원보다 작을 수 없습니다.");
-	private static final ErrorCode RESOURCE_NOT_FOUND = new ErrorCode("RESOURCE_NOT_FOUND", " 리소스를 찾을 수 없습니다.");
+	public static final ErrorCode RESOURCE_NOT_FOUND = new ErrorCode("RESOURCE_NOT_FOUND", "리소스를 찾을 수 없습니다.");
+	public static final ErrorCode DATA_INTEGRITY_VIOLATION = new ErrorCode("DATA_INTEGRITY_VIOLATION",
+		"DB 오류가 발생했습니다.");
 
 	private final String errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
+++ b/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.flab.weshare.exception.advice;
 
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,6 +26,13 @@ public class ControllerAdvice {
 		return BaseResponse.fail(ErrorResponse.of(ErrorCode.INTRENAL_SERVER_ERROR));
 	}
 
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public BaseResponse commonExceptionHandler(DataIntegrityViolationException dataIntegrityViolationException) {
+		log.error("exception :", dataIntegrityViolationException);
+		return BaseResponse.fail(ErrorResponse.of(ErrorCode.DATA_INTEGRITY_VIOLATION));
+	}
+
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(CommonClientException.class)
 	public BaseResponse commonExceptionHandler(CommonClientException commonClientException) {
@@ -39,7 +47,7 @@ public class ControllerAdvice {
 		return BaseResponse.fail(ErrorResponse.of(ErrorCode.INVALID_INPUT, extractFieldErrors(bindException)));
 	}
 
-	private List<ErrorResponse.FieldError> extractFieldErrors (BindException bindException){
+	private List<ErrorResponse.FieldError> extractFieldErrors(BindException bindException) {
 		return bindException.getBindingResult()
 			.getFieldErrors()
 			.stream()

--- a/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
@@ -102,7 +102,7 @@ class PartyServiceTest {
 		given(mockParty.getOtt()).willReturn(savedOtt);
 		given(mockParty.isChangeableCapacity(anyInt())).willReturn(true);
 
-		partyService.updatePartyDetails(1L, modifyPartyRequest);
+		partyService.updatePartyDetails(modifyPartyRequest, 1L);
 		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
 		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
 	}
@@ -116,7 +116,7 @@ class PartyServiceTest {
 		given(mockParty.getOtt()).willReturn(savedOtt);
 		given(mockParty.isChangeableCapacity(anyInt())).willReturn(false);
 
-		assertThatThrownBy(() -> partyService.updatePartyDetails(1L, modifyPartyRequest))
+		assertThatThrownBy(() -> partyService.updatePartyDetails(modifyPartyRequest, 1L))
 			.isInstanceOf(CommonClientException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.INSUFFICIENT_CAPACITY);


### PR DESCRIPTION
> 저번 merge된 PR에 리뷰해주신 내용 수정하고 푸쉬해서 main에 이미 merge되었습니다.
> 방금 올렸던 pr에 저번 pr 내용이 모두 중복해서 들어간거 같습니다.
> 일단 브랜치를 다시 분기해서 이번에 작업한 내용만 다시 pr올립니다. 밑의 pr은 닫겠습니다

## 설명
- [#17] Party 가입 요청 api 구현

## 작업 내용
- Party 가입 요청 api 구현
- Spring Data Jpa에서 제약 조건 위반을 핸들하는 `DataIntegrityException`을 `ControllerAdvice`에서 일괄처리

Party 요청이 들어오면 `PartyJoin`테이블에 저장하여 일시적으로 대기 시킨 후 배치작업으로 파티 매칭을 하는 방향을 생각중입니다.