### PR TITLE
[#13] 파티 도메인 핵심 로직 변경

### DIFF
--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyMemberController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyMemberController.java
@@ -1,0 +1,15 @@
+package com.flab.weshare.domain.party.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/party")
+public class PartyMemberController {
+
+}

--- a/src/main/java/com/flab/weshare/domain/party/entity/Party.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Party.java
@@ -23,7 +23,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicUpdate
@@ -87,14 +89,23 @@ public class Party extends BaseEntity {
 	}
 
 	public void deleteEmptyCapsules(final int newCapacity) {
+		log.debug("current Capusule size = {}", getCapsulesSize());
+		log.debug("current capacity = {}", this.capacity);
+		log.debug("current newCapacity = {}", newCapacity);
+
 		if (this.partyCapsules.size() <= newCapacity) {
 			return;
 		}
 
 		for (PartyCapsule partyCapsule : this.partyCapsules) {
-			if (partyCapsule.getPartyCapsuleStatus().equals(PartyCapsuleStatus.EMPTY)) {
+			if (partyCapsule.isEmptyCapsule()) {
 				partyCapsule.deleteCapsule();
+				this.partyCapsules.remove(partyCapsule);
 			}
+
+			log.debug("current partyCapsules Occupied = {}", countOccupiedPartyCapsule());
+			log.debug("current Capusule size = {}", getCapsulesSize());
+
 			if (this.partyCapsules.size() == newCapacity) {
 				return;
 			}

--- a/src/main/java/com/flab/weshare/domain/party/entity/Party.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Party.java
@@ -86,15 +86,16 @@ public class Party extends BaseEntity {
 		this.ottAccountPassword = encodedPassword;
 	}
 
-	public void deleteEmptyCapsules(final int deleteTargetCount) {
-		int deleteChecks = deleteTargetCount;
+	public void deleteEmptyCapsules(final int newCapacity) {
+		if (this.partyCapsules.size() <= newCapacity) {
+			return;
+		}
 
 		for (PartyCapsule partyCapsule : this.partyCapsules) {
 			if (partyCapsule.getPartyCapsuleStatus().equals(PartyCapsuleStatus.EMPTY)) {
 				partyCapsule.deleteCapsule();
-				--deleteChecks;
 			}
-			if (deleteChecks == 0) {
+			if (this.partyCapsules.size() == newCapacity) {
 				return;
 			}
 		}

--- a/src/main/java/com/flab/weshare/domain/party/entity/Party.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/Party.java
@@ -56,7 +56,7 @@ public class Party extends BaseEntity {
 	private PartyStatus partyStatus;
 
 	@OneToMany(mappedBy = "party")
-	private List<PartyMember> partyMembers = new ArrayList<>();
+	private List<PartyCapsule> partyCapsules = new ArrayList<>(); //EMPTY, OCCUPIED 상태의 PartyCapsule 만 존재.
 
 	@Builder
 	private Party(User leader, Ott ott, String ottAccountId, String ottAccountPassword, int capacity) {
@@ -72,11 +72,31 @@ public class Party extends BaseEntity {
 		this.capacity = capacity;
 	}
 
-	public boolean isChangeableCapacity(int capacity) {
-		return this.partyMembers.size() <= capacity - 1;
+	public int getCapsulesSize() {
+		return this.partyCapsules.size();
+	}
+
+	public int countOccupiedPartyCapsule() {
+		return (int)partyCapsules.stream()
+			.filter(pc -> pc.getPartyCapsuleStatus().equals(PartyCapsuleStatus.OCCUPIED))
+			.count();
 	}
 
 	public void changePassword(String encodedPassword) {
 		this.ottAccountPassword = encodedPassword;
+	}
+
+	public void deleteEmptyCapsules(final int deleteTargetCount) {
+		int deleteChecks = deleteTargetCount;
+
+		for (PartyCapsule partyCapsule : this.partyCapsules) {
+			if (partyCapsule.getPartyCapsuleStatus().equals(PartyCapsuleStatus.EMPTY)) {
+				partyCapsule.deleteCapsule();
+				--deleteChecks;
+			}
+			if (deleteChecks == 0) {
+				return;
+			}
+		}
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
@@ -21,10 +21,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class PartyMember extends BaseEntity {
+public class PartyCapsule extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "party_member_id")
+	@Column(name = "party_capsule_id")
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -36,12 +36,23 @@ public class PartyMember extends BaseEntity {
 	private Party party;
 
 	@Enumerated(value = EnumType.STRING)
-	private PartyMemberStatus partyMemberStatus;
+	private PartyCapsuleStatus partyCapsuleStatus;
 
 	@Builder
-	public PartyMember(User partyMember, Party party, PartyMemberStatus partyMemberStatus) {
+	private PartyCapsule(User partyMember, Party party, PartyCapsuleStatus partyCapsuleStatus) {
 		this.partyMember = partyMember;
 		this.party = party;
-		this.partyMemberStatus = PartyMemberStatus.ATTENDING;
+		this.partyCapsuleStatus = partyCapsuleStatus;
+	}
+
+	public static PartyCapsule makeEmptyCapsule(Party party) {
+		return PartyCapsule.builder()
+			.party(party)
+			.partyCapsuleStatus(PartyCapsuleStatus.EMPTY)
+			.build();
+	}
+
+	public void deleteCapsule() {
+		this.partyCapsuleStatus = PartyCapsuleStatus.DELETED;
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
@@ -52,6 +52,10 @@ public class PartyCapsule extends BaseEntity {
 			.build();
 	}
 
+	public boolean isEmptyCapsule() {
+		return this.partyCapsuleStatus.equals(PartyCapsuleStatus.EMPTY);
+	}
+
 	public void deleteCapsule() {
 		this.partyCapsuleStatus = PartyCapsuleStatus.DELETED;
 	}

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsuleStatus.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsuleStatus.java
@@ -1,0 +1,9 @@
+package com.flab.weshare.domain.party.entity;
+
+public enum PartyCapsuleStatus {
+	EMPTY //빈 상태
+	, OCCUPIED //파티원에 의해 점유중
+	, WITHDRAWN //파티원이 파티에서 이탈
+	, DELETED //삭제됨
+	, CLOSED //파티가 닫힘으로 인해 종료.
+}

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyMemberStatus.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyMemberStatus.java
@@ -1,5 +1,0 @@
-package com.flab.weshare.domain.party.entity;
-
-public enum PartyMemberStatus {
-	ATTENDING, WITHDRAWN, CANCELED
-}

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
@@ -1,0 +1,8 @@
+package com.flab.weshare.domain.party.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+
+public interface PartyCapsuleRepository extends JpaRepository<PartyCapsule, Long> {
+}

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
@@ -3,13 +3,23 @@ package com.flab.weshare.domain.party.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.flab.weshare.domain.party.entity.Party;
 
+import jakarta.persistence.LockModeType;
+
 public interface PartyRepository extends JpaRepository<Party, Long> {
 
-	@Query("select p from Party p left join fetch p.partyMembers join fetch p.ott where p.id =:partyId")
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select p "
+		+ "from Party p "
+		+ "join fetch p.partyCapsules pc "
+		+ "join fetch p.ott "
+		+ "where p.id =:partyId "
+		+ "and pc.partyCapsuleStatus in (com.flab.weshare.domain.party.entity.PartyCapsuleStatus.EMPTY,"
+		+ "com.flab.weshare.domain.party.entity.PartyCapsuleStatus.OCCUPIED)")
 	Optional<Party> findFetchByPartyId(@Param("partyId") Long partyId);
 }

--- a/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
@@ -16,10 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.weshare.config.TestContainerConfig;
-import com.flab.weshare.domain.party.entity.PartyMember;
-import com.flab.weshare.domain.party.entity.PartyMemberStatus;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.party.entity.PartyCapsuleStatus;
 import com.flab.weshare.domain.party.repository.OttRepository;
-import com.flab.weshare.domain.party.repository.PartyMemberRepository;
+import com.flab.weshare.domain.party.repository.PartyCapsuleRepository;
 import com.flab.weshare.domain.party.repository.PartyRepository;
 import com.flab.weshare.domain.user.entity.Role;
 import com.flab.weshare.domain.user.entity.User;
@@ -51,7 +51,7 @@ public abstract class BaseControllerTest {
 	protected PartyRepository partyRepository;
 
 	@Autowired
-	protected PartyMemberRepository partyMemberRepository;
+	protected PartyCapsuleRepository partyCapsuleRepository;
 
 	@Autowired
 	EntityManager entityManager;
@@ -77,28 +77,28 @@ public abstract class BaseControllerTest {
 		List<User> users = createUsers();
 		userRepository.saveAll(users);
 
-		List<PartyMember> partyMembers = createPartyMembers(users);
-		partyMemberRepository.saveAll(partyMembers);
+		List<PartyCapsule> partyCapsules = createPartyCapsules(users);
+		partyCapsuleRepository.saveAll(partyCapsules);
 
 		entityManager.clear();
 	}
 
-	private List<PartyMember> createPartyMembers(List<User> users) {
-		List<PartyMember> partyMembers = new ArrayList<>();
+	private List<PartyCapsule> createPartyCapsules(List<User> users) {
+		List<PartyCapsule> partyCapsules = new ArrayList<>();
 		for (int i = 0; i < 2; i++) {
-			PartyMember partyMember = PartyMember.builder()
+			PartyCapsule partyCapsule = PartyCapsule.builder()
 				.party(savedParty)
 				.partyMember(users.get(i))
-				.partyMemberStatus(PartyMemberStatus.ATTENDING)
+				.partyCapsuleStatus(PartyCapsuleStatus.OCCUPIED)
 				.build();
-			partyMembers.add(partyMember);
+			partyCapsules.add(partyCapsule);
 		}
-		return partyMembers;
+		return partyCapsules;
 	}
 
 	private List<User> createUsers() {
 		List<User> members = new ArrayList<>();
-		for (int i = 0; i < 2; i++) {
+		for (int i = 0; i < 3; i++) {
 			User build = User.builder()
 				.nickName(NICKNAME + i)
 				.email(EMAIL + i)

--- a/src/test/java/com/flab/weshare/domain/base/BaseRepositoryTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseRepositoryTest.java
@@ -5,6 +5,7 @@ import static com.flab.weshare.domain.utils.TestUtil.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -15,10 +16,10 @@ import org.springframework.test.context.ActiveProfiles;
 import com.flab.weshare.config.TestContainerConfig;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.Party;
-import com.flab.weshare.domain.party.entity.PartyMember;
-import com.flab.weshare.domain.party.entity.PartyMemberStatus;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.party.entity.PartyCapsuleStatus;
 import com.flab.weshare.domain.party.repository.OttRepository;
-import com.flab.weshare.domain.party.repository.PartyMemberRepository;
+import com.flab.weshare.domain.party.repository.PartyCapsuleRepository;
 import com.flab.weshare.domain.party.repository.PartyRepository;
 import com.flab.weshare.domain.user.entity.Role;
 import com.flab.weshare.domain.user.entity.User;
@@ -36,7 +37,7 @@ public abstract class BaseRepositoryTest {
 	protected PartyRepository partyRepository;
 
 	@Autowired
-	protected PartyMemberRepository partyMemberRepository;
+	protected PartyCapsuleRepository partyCapsuleRepository;
 
 	@Autowired
 	protected OttRepository ottRepository;
@@ -45,8 +46,74 @@ public abstract class BaseRepositoryTest {
 
 	@BeforeEach
 	void setUp() {
+		List<User> members = generateMembers();
+		userRepository.save(savedUser);
+		userRepository.saveAll(members);
+
+		Ott testOtt = generteOtt();
+		ottRepository.save(testOtt);
+		savedParty = generteParty(testOtt);
+		partyRepository.save(savedParty);
+
+		List<PartyCapsule> partyCapsules = preparePartyCapsules(members);
+		partyCapsuleRepository.saveAll(partyCapsules);
+	}
+
+	@NotNull
+	private List<PartyCapsule> preparePartyCapsules(List<User> members) {
+		List<PartyCapsule> partyCapsules = new ArrayList<>();
+		addOccupied(members, partyCapsules);
+		partyCapsules.add(PartyCapsule.makeEmptyCapsule(savedParty));
+		addWithdrawns(members, partyCapsules);
+		return partyCapsules;
+	}
+
+	private void addWithdrawns(List<User> members, List<PartyCapsule> partyCapsules) {
+		for (int i = 10; i < 15; i++) {
+			PartyCapsule build = PartyCapsule.builder()
+				.party(savedParty)
+				.partyMember(members.get(i))
+				.partyCapsuleStatus(PartyCapsuleStatus.WITHDRAWN)
+				.build();
+			partyCapsules.add(build);
+		}
+	}
+
+	private void addOccupied(List<User> members, List<PartyCapsule> partyCapsules) {
+		for (int i = 0; i < 2; i++) {
+			PartyCapsule build = PartyCapsule.builder()
+				.party(savedParty)
+				.partyMember(members.get(i))
+				.partyCapsuleStatus(PartyCapsuleStatus.OCCUPIED)
+				.build();
+			partyCapsules.add(build);
+		}
+	}
+
+	private Party generteParty(Ott testOtt) {
+		return Party.builder()
+			.leader(savedUser)
+			.ott(testOtt)
+			.capacity(4)
+			.ottAccountId("dsafadsfd")
+			.ottAccountPassword("adsfeeff33")
+			.build();
+	}
+
+	private Ott generteOtt() {
+		Ott testOtt = Ott.builder()
+			.name("test")
+			.leaderFee(3000)
+			.commonFee(2000)
+			.maximumCapacity(3)
+			.build();
+		return testOtt;
+	}
+
+	@NotNull
+	private List<User> generateMembers() {
 		List<User> members = new ArrayList<>();
-		for (int i = 0; i < 4; i++) {
+		for (int i = 0; i < 15; i++) {
 			User build = User.builder()
 				.nickName(NICKNAME + i)
 				.email(EMAIL)
@@ -57,37 +124,7 @@ public abstract class BaseRepositoryTest {
 
 			members.add(build);
 		}
-
-		userRepository.save(savedUser);
-		userRepository.saveAll(members);
-
-		Ott testOtt = Ott.builder()
-			.name("test")
-			.leaderFee(3000)
-			.commonFee(2000)
-			.maximumCapacity(4)
-			.build();
-
-		ottRepository.save(testOtt);
-
-		savedParty = Party.builder()
-			.leader(savedUser)
-			.ott(testOtt)
-			.capacity(4)
-			.ottAccountId("dsafadsfd")
-			.ottAccountPassword("adsfeeff33")
-			.build();
-
-		partyRepository.save(savedParty);
-
-		for (int i = 0; i < 3; i++) {
-			PartyMember build = PartyMember.builder()
-				.party(savedParty)
-				.partyMember(members.get(i))
-				.partyMemberStatus(PartyMemberStatus.ATTENDING)
-				.build();
-			partyMemberRepository.save(build);
-		}
+		return members;
 	}
 
 }

--- a/src/test/java/com/flab/weshare/domain/base/BaseServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseServiceTest.java
@@ -1,0 +1,8 @@
+package com.flab.weshare.domain.base;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class BaseServiceTest {
+}

--- a/src/test/java/com/flab/weshare/domain/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/controller/PartyControllerTest.java
@@ -64,7 +64,7 @@ class PartyControllerTest extends BaseControllerTest {
 	@DisplayName("현재 파티의 인원수보다 적게 정원수를 변경할 수 없다.")
 	@Test
 	void failPartyUpdate() throws Exception {
-		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(2, "asddff222");
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(1, "asddff222");
 		mockMvc.perform(put("/api/v1/party/" + savedParty.getId())
 				.header(JwtProperties.HEADER, ACCESS_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
@@ -78,7 +78,7 @@ class PartyControllerTest extends BaseControllerTest {
 	@DisplayName("파티요청을 생성할 수 있다.")
 	@Test
 	void success_party_join_creation() throws Exception {
-		PartyJoinRequest partyCreationRequest = new PartyJoinRequest(savedParty.getId());
+		PartyJoinRequest partyCreationRequest = new PartyJoinRequest(savedOtt.getId());
 
 		mockMvc.perform(post("/api/v1/party/join")
 				.header(JwtProperties.HEADER, ACCESS_TOKEN)

--- a/src/test/java/com/flab/weshare/domain/party/repository/PartyRepositoryTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/repository/PartyRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.flab.weshare.domain.party.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.flab.weshare.domain.base.BaseRepositoryTest;
+import com.flab.weshare.domain.party.entity.Party;
+
+import jakarta.persistence.EntityManager;
+
+class PartyRepositoryTest extends BaseRepositoryTest {
+	@Autowired
+	EntityManager em;
+
+	@Test
+	void fetchTest() {
+		em.clear();
+		Optional<Party> fetchByPartyId = partyRepository.findFetchByPartyId(savedParty.getId());
+		Party party = fetchByPartyId.get();
+
+		assertThat(fetchByPartyId)
+			.isNotEmpty();
+		assertThat(party.getCapsulesSize()).isEqualTo(3);
+		assertThat(party.countOccupiedPartyCapsule()).isEqualTo(2);
+	}
+}

--- a/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
@@ -4,11 +4,13 @@ import static com.flab.weshare.domain.utils.TestUtil.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,7 +20,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
 import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.party.entity.PartyCapsuleStatus;
 import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.party.repository.PartyCapsuleRepository;
 import com.flab.weshare.domain.party.repository.PartyRepository;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.exception.ErrorCode;
@@ -33,6 +38,9 @@ class PartyServiceTest {
 	PartyRepository partyRepository;
 
 	@Mock
+	PartyCapsuleRepository partyCapsuleRepository;
+
+	@Mock
 	OttRepository ottRepository;
 
 	@Mock
@@ -44,7 +52,7 @@ class PartyServiceTest {
 	@Mock
 	private Party mockParty;
 
-	@DisplayName("유효한 파티 생성 요청일 시 데이터베이스에 저장.")
+	@DisplayName("유효한 파티 생성 요청일 시 파티와 빈 파티 캡슐을 정원 만큼 생성하며 데이터베이스 저장한다.")
 	@Test
 	void generate_party_sucesss() {
 		PartyCreationRequest partyCreationRequest = new PartyCreationRequest(
@@ -59,6 +67,14 @@ class PartyServiceTest {
 		partyService.generateParty(partyCreationRequest, savedUser.getId());
 
 		then(partyRepository).should(times(1)).save(any(Party.class));
+		then(partyCapsuleRepository).should(times(1))
+			.saveAll(ArgumentMatchers.argThat(
+				argument -> argument instanceof List<PartyCapsule>
+					&& ((List<PartyCapsule>)argument).size() == PARTY_MAXIMUM_CAPACITY //파티의 정원 만큼 파티캡슐을 생성하는가
+					&& ((List<PartyCapsule>)argument).stream() //파티 캡슐이 모두 빈 상태로 생성되는가
+					.allMatch(partyCapsule
+						-> partyCapsule.getPartyCapsuleStatus().equals(PartyCapsuleStatus.EMPTY))
+			));
 	}
 
 	@DisplayName("생성하려는 파티의 ott를 찾을 수 없는경우 예외를 반환")
@@ -82,10 +98,6 @@ class PartyServiceTest {
 			1L, OTT_ACCOUNT_ID, OTT_PASSWORD, MAXIMUM_CAPACITY + 1);
 
 		given(ottRepository.findById(anyLong())).willReturn(Optional.of(savedOtt));
-		given(userRepository.getReferenceById(anyLong())).willReturn(savedUser);
-
-		ReflectionTestUtils.setField(savedOtt, "id", 1L);
-		ReflectionTestUtils.setField(savedUser, "id", 1L);
 
 		assertThatThrownBy(() -> partyService.generateParty(partyCreationRequest, 1L))
 			.isInstanceOf(CommonClientException.class)
@@ -93,28 +105,68 @@ class PartyServiceTest {
 			.isEqualTo(ErrorCode.INVALID_CAPACITY);
 	}
 
-	@DisplayName("유효한 파티 수정요청일 경우 파티의 상태를 업데이트한다.")
+	@DisplayName("파티 수정 성공 - 1. 정원 감소")
 	@Test
-	void update_party_success() {
-		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(3, PASSWORD);
+	void update_party_success_decrease_capacity() {
+		int newCapacity = 2;
+		int partyCapsuleSize = 3;
+		int occupiedCapsuleCount = 2;
+
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(newCapacity, PASSWORD);
 
 		given(partyRepository.findFetchByPartyId(anyLong())).willReturn(Optional.of(mockParty));
-		given(mockParty.getOtt()).willReturn(savedOtt);
-		given(mockParty.isChangeableCapacity(anyInt())).willReturn(true);
+		given(mockParty.getOtt()).willReturn(savedOtt); //현재 ott 최대 정원 : 4
+		given(mockParty.countOccupiedPartyCapsule()).willReturn(occupiedCapsuleCount); //현재 파티에 참여 중인 인원 : 2
+		given(mockParty.getCapsulesSize()).willReturn(partyCapsuleSize); // 전체 캡슐수 : 3 빈 캡슐 : 1 상황 가정
 
 		partyService.updatePartyDetails(modifyPartyRequest, 1L);
+
+		then(mockParty).should(times(1)).deleteEmptyCapsules(partyCapsuleSize - newCapacity);
 		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
 		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
+		then(partyCapsuleRepository).should(never()).saveAll(anyCollection());
 	}
 
-	@DisplayName("현재 파티 인원보다 적게 변경하는 요청시 예외를 반환")
+	@DisplayName("파티 수정 성공 - 2. 정원 증가")
+	@Test
+	void update_party_success_increase_capacity() {
+		int newCapacity = 4;
+		int partyCapsuleSize = 3;
+		int occupiedCapsuleCount = 2;
+
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(newCapacity, PASSWORD);
+
+		given(partyRepository.findFetchByPartyId(anyLong())).willReturn(Optional.of(mockParty));
+		given(mockParty.getOtt()).willReturn(savedOtt); //현 재 ott 최대 정원 : 4
+		given(mockParty.countOccupiedPartyCapsule()).willReturn(occupiedCapsuleCount); //현재 파티에 참여 중인 인원 : 2
+		given(mockParty.getCapsulesSize()).willReturn(partyCapsuleSize); // 전체 캡슐수 : 3 빈 캡슐 : 1 상황 가정
+
+		partyService.updatePartyDetails(modifyPartyRequest, 1L);
+
+		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
+		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
+		then(partyCapsuleRepository).should(times(1))
+			.saveAll(ArgumentMatchers.argThat(
+				argument -> argument instanceof List<PartyCapsule>
+					&& ((List<PartyCapsule>)argument).size() == newCapacity - partyCapsuleSize
+					&& ((List<PartyCapsule>)argument).stream()
+					.allMatch(partyCapsule
+						-> partyCapsule.getPartyCapsuleStatus().equals(PartyCapsuleStatus.EMPTY))
+			));
+	}
+
+	@DisplayName("현재 파티 점유인원 보다 정원을 적게 변경하는 요청시 예외를 반환")
 	@Test
 	void update_party_fail() {
-		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(3, PASSWORD);
+		int newCapacity = 2;
+		int partyCapsuleSize = 3;
+		int occupiedCapsuleCount = 3;
+
+		ModifyPartyRequest modifyPartyRequest = new ModifyPartyRequest(newCapacity, PASSWORD);
 
 		given(partyRepository.findFetchByPartyId(anyLong())).willReturn(Optional.of(mockParty));
 		given(mockParty.getOtt()).willReturn(savedOtt);
-		given(mockParty.isChangeableCapacity(anyInt())).willReturn(false);
+		given(mockParty.countOccupiedPartyCapsule()).willReturn(occupiedCapsuleCount);
 
 		assertThatThrownBy(() -> partyService.updatePartyDetails(modifyPartyRequest, 1L))
 			.isInstanceOf(CommonClientException.class)

--- a/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/service/PartyServiceTest.java
@@ -121,7 +121,7 @@ class PartyServiceTest {
 
 		partyService.updatePartyDetails(modifyPartyRequest, 1L);
 
-		then(mockParty).should(times(1)).deleteEmptyCapsules(partyCapsuleSize - newCapacity);
+		then(mockParty).should(times(1)).deleteEmptyCapsules(newCapacity);
 		then(mockParty).should(times(1)).changePassword(passwordEncoder.encode(modifyPartyRequest.password()));
 		then(mockParty).should(times(1)).changeCapacity(modifyPartyRequest.capacity());
 		then(partyCapsuleRepository).should(never()).saveAll(anyCollection());

--- a/src/test/java/com/flab/weshare/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/user/controller/UserControllerTest.java
@@ -4,31 +4,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.weshare.domain.base.BaseControllerTest;
 import com.flab.weshare.domain.user.dto.SignUpRequest;
 
-@Transactional
-@SpringBootTest
-@AutoConfigureMockMvc
-class UserControllerTest {
-	@Autowired
-	MockMvc mockMvc;
-
-	@Autowired
-	ObjectMapper objectMapper;
-
+class UserControllerTest extends BaseControllerTest {
 	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "fffdfdf2@", "test", "01011111111");
 
 	@Test
 	void signup_test() throws Exception {
-		mockMvc.perform(post("/api/user")
+		mockMvc.perform(post("/api/v1/user")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(signUpRequest)))
 			.andExpect(status().isCreated());

--- a/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/weshare/domain/user/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.flab.weshare.domain.user.dto.SignUpRequest;
 import com.flab.weshare.domain.user.entity.User;
@@ -22,6 +23,9 @@ class UserServiceTest {
 
 	@Mock
 	UserRepository userRepository;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
 
 	SignUpRequest signUpRequest = new SignUpRequest("test@email.com", "fffdfdf2@", "test", "01011111111");
 


### PR DESCRIPTION
## 설명
- [#13] 파티 도메인 핵심 로직 변경

## 작업 내용
- 파티의 빈 자리를 효율적으로 관리하기 위해 기존 `PartyMember`를 `PartyCapsule`로 변경하였습니다.
- 파티의 생성과 수정시 빈 `PartyCapsule`을 추가하거나 삭제하는 로직을 추가하였습니다.
- 이에따른 테스트 로직을 변경하였습니다.

