### PR TITLE
[#17] 파티 매칭구현

### DIFF
--- a/src/main/java/com/flab/weshare/WeshareApplication.java
+++ b/src/main/java/com/flab/weshare/WeshareApplication.java
@@ -3,8 +3,10 @@ package com.flab.weshare;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class WeshareApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/flab/weshare/config/AsyncConfiguration.java
+++ b/src/main/java/com/flab/weshare/config/AsyncConfiguration.java
@@ -1,0 +1,25 @@
+package com.flab.weshare.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfiguration implements AsyncConfigurer {
+
+	@Override
+	public Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+		threadPoolTaskExecutor.setThreadNamePrefix("async-thread-");
+		threadPoolTaskExecutor.setCorePoolSize(20);
+		threadPoolTaskExecutor.setMaxPoolSize(40);
+		threadPoolTaskExecutor.setQueueCapacity(400);
+		threadPoolTaskExecutor.setKeepAliveSeconds(30);
+		threadPoolTaskExecutor.initialize();
+		return threadPoolTaskExecutor;
+	}
+}

--- a/src/main/java/com/flab/weshare/config/AsyncConfiguration.java
+++ b/src/main/java/com/flab/weshare/config/AsyncConfiguration.java
@@ -2,6 +2,7 @@ package com.flab.weshare.config;
 
 import java.util.concurrent.Executor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -10,15 +11,29 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @EnableAsync
 @Configuration
 public class AsyncConfiguration implements AsyncConfigurer {
+	@Value(value = "async.prefix")
+	private static String threadNamePrefix;
+
+	@Value(value = "async.corePoolSize")
+	private static int corePoolSize;
+
+	@Value(value = "async.maxPoolSize")
+	private static int maxPoolSize;
+
+	@Value(value = "async.queueCapacity")
+	private static int queueCapacity;
+
+	@Value(value = "async.keepAliveSeconds")
+	private static int keepAliveSeconds;
 
 	@Override
 	public Executor getAsyncExecutor() {
 		ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
-		threadPoolTaskExecutor.setThreadNamePrefix("async-thread-");
-		threadPoolTaskExecutor.setCorePoolSize(20);
-		threadPoolTaskExecutor.setMaxPoolSize(40);
-		threadPoolTaskExecutor.setQueueCapacity(400);
-		threadPoolTaskExecutor.setKeepAliveSeconds(30);
+		threadPoolTaskExecutor.setThreadNamePrefix(threadNamePrefix);
+		threadPoolTaskExecutor.setCorePoolSize(corePoolSize);
+		threadPoolTaskExecutor.setMaxPoolSize(maxPoolSize);
+		threadPoolTaskExecutor.setQueueCapacity(queueCapacity);
+		threadPoolTaskExecutor.setKeepAliveSeconds(keepAliveSeconds);
 		threadPoolTaskExecutor.initialize();
 		return threadPoolTaskExecutor;
 	}

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
@@ -59,4 +59,9 @@ public class PartyCapsule extends BaseEntity {
 	public void deleteCapsule() {
 		this.partyCapsuleStatus = PartyCapsuleStatus.DELETED;
 	}
+
+	public void occupy(final User user) {
+		this.partyMember = user;
+		this.partyCapsuleStatus = PartyCapsuleStatus.PRE_OCCUPIED;
+	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsuleStatus.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsuleStatus.java
@@ -6,4 +6,5 @@ public enum PartyCapsuleStatus {
 	, WITHDRAWN //파티원이 파티에서 이탈
 	, DELETED //삭제됨
 	, CLOSED //파티가 닫힘으로 인해 종료.
+	, PRE_OCCUPIED
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
@@ -45,7 +45,7 @@ public class PartyJoin extends BaseEntity {
 		this.partyJoinStatus = partyJoinStatus;
 	}
 
-	public static PartyJoin genertaeWaitingPartyJoin(User user, Ott ott) {
+	public static PartyJoin generateWaitingPartyJoin(User user, Ott ott) {
 		return PartyJoin.builder()
 			.partyJoinStatus(PartyJoinStatus.WAITING)
 			.user(user)

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
@@ -39,9 +39,21 @@ public class PartyJoin extends BaseEntity {
 	private PartyJoinStatus partyJoinStatus;
 
 	@Builder
-	private PartyJoin(User user, Ott ott) {
+	private PartyJoin(User user, Ott ott, PartyJoinStatus partyJoinStatus) {
 		this.user = user;
 		this.ott = ott;
-		this.partyJoinStatus = PartyJoinStatus.WAITING;
+		this.partyJoinStatus = partyJoinStatus;
+	}
+
+	public static PartyJoin genertaeWaitingPartyJoin(User user, Ott ott) {
+		return PartyJoin.builder()
+			.partyJoinStatus(PartyJoinStatus.WAITING)
+			.user(user)
+			.ott(ott)
+			.build();
+	}
+
+	public boolean isWaitingPartyJoin() {
+		return this.partyJoinStatus.equals(PartyJoinStatus.WAITING);
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoin.java
@@ -56,4 +56,8 @@ public class PartyJoin extends BaseEntity {
 	public boolean isWaitingPartyJoin() {
 		return this.partyJoinStatus.equals(PartyJoinStatus.WAITING);
 	}
+
+	public void changeStatusPayWaiting() {
+		this.partyJoinStatus = PartyJoinStatus.PAY_WAITING;
+	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyJoinStatus.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyJoinStatus.java
@@ -1,5 +1,5 @@
 package com.flab.weshare.domain.party.entity;
 
 public enum PartyJoinStatus {
-	WAITING, JOINED
+	WAITING, JOINED, PAY_WAITING
 }

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
@@ -1,8 +1,26 @@
 package com.flab.weshare.domain.party.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.user.entity.User;
 
 public interface PartyCapsuleRepository extends JpaRepository<PartyCapsule, Long> {
+	@Query("select pc "
+		+ "from PartyCapsule pc "
+		+ "where pc.party.ott =:ott and pc.partyCapsuleStatus = com.flab.weshare.domain.party.entity.PartyCapsuleStatus.EMPTY "
+		+ "order by pc.createdDate asc")
+	List<PartyCapsule> findEmptyCapsuleByOtt(@Param("ott") Ott ott);
+
+	@Modifying
+	@Query("update PartyCapsule pc "
+		+ "set pc.partyMember=:user , pc.partyCapsuleStatus = com.flab.weshare.domain.party.entity.PartyCapsuleStatus.OCCUPIED"
+		+ " where pc=:partyCapsule")
+	void updatePartyCapusuleOccupy(@Param("user") User user, @Param("partyCapsule") PartyCapsule partyCapsule);
 }

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
@@ -1,15 +1,17 @@
 package com.flab.weshare.domain.party.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyCapsule;
-import com.flab.weshare.domain.user.entity.User;
+
+import jakarta.persistence.LockModeType;
 
 public interface PartyCapsuleRepository extends JpaRepository<PartyCapsule, Long> {
 	@Query("select pc "
@@ -18,9 +20,9 @@ public interface PartyCapsuleRepository extends JpaRepository<PartyCapsule, Long
 		+ "order by pc.createdDate asc")
 	List<PartyCapsule> findEmptyCapsuleByOtt(@Param("ott") Ott ott);
 
-	@Modifying
-	@Query("update PartyCapsule pc "
-		+ "set pc.partyMember=:user , pc.partyCapsuleStatus = com.flab.weshare.domain.party.entity.PartyCapsuleStatus.OCCUPIED"
-		+ " where pc=:partyCapsule")
-	void updatePartyCapusuleOccupy(@Param("user") User user, @Param("partyCapsule") PartyCapsule partyCapsule);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select pc "
+		+ "from PartyCapsule pc "
+		+ "where pc.id =:partyCapsuleId")
+	Optional<PartyCapsule> findByIdForUpdate(@Param("partyCapsuleId") Long partyCapsuleId);
 }

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
@@ -1,8 +1,25 @@
 package com.flab.weshare.domain.party.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyJoin;
 
 public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
+	@Query("select pj "
+		+ "from PartyJoin pj "
+		+ "where pj.ott =:ott and pj.partyJoinStatus = com.flab.weshare.domain.party.entity.PartyJoinStatus.WAITING "
+		+ "order by pj.createdDate asc")
+	List<PartyJoin> findWaitingPartyJoinByOtt(@Param("ott") Ott ott);
+
+	@Modifying
+	@Query("update PartyJoin pj "
+		+ "set pj.partyJoinStatus= com.flab.weshare.domain.party.entity.PartyJoinStatus.PAY_WAITING"
+		+ " where pj=:partyJoin")
+	void updatePartyJoinPayWaiting(@Param("partyJoin") PartyJoin partyJoin);
 }

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyJoinRepository.java
@@ -1,14 +1,17 @@
 package com.flab.weshare.domain.party.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyJoin;
+
+import jakarta.persistence.LockModeType;
 
 public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
 	@Query("select pj "
@@ -17,9 +20,9 @@ public interface PartyJoinRepository extends JpaRepository<PartyJoin, Long> {
 		+ "order by pj.createdDate asc")
 	List<PartyJoin> findWaitingPartyJoinByOtt(@Param("ott") Ott ott);
 
-	@Modifying
-	@Query("update PartyJoin pj "
-		+ "set pj.partyJoinStatus= com.flab.weshare.domain.party.entity.PartyJoinStatus.PAY_WAITING"
-		+ " where pj=:partyJoin")
-	void updatePartyJoinPayWaiting(@Param("partyJoin") PartyJoin partyJoin);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select pj "
+		+ "from PartyJoin pj "
+		+ "where pj.id =:partyJoinId")
+	Optional<PartyJoin> findByIdForUpdate(@Param("partyJoinId") Long partyJoinId);
 }

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -121,7 +121,7 @@ public class PartyService {
 		User partyParticipant = userRepository.getReferenceById(userId);
 		Ott selectedOtt = ottRepository.getReferenceById(PartyJoinRequest.ottId());
 
-		PartyJoin partyJoin = PartyJoin.genertaeWaitingPartyJoin(partyParticipant, selectedOtt);
+		PartyJoin partyJoin = PartyJoin.generateWaitingPartyJoin(partyParticipant, selectedOtt);
 		partyJoinRepository.save(partyJoin);
 
 		return partyJoin.getId();

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -121,13 +121,34 @@ public class PartyService {
 		User partyParticipant = userRepository.getReferenceById(userId);
 		Ott selectedOtt = ottRepository.getReferenceById(PartyJoinRequest.ottId());
 
-		PartyJoin partyJoin = PartyJoin.builder()
-			.ott(selectedOtt)
-			.user(partyParticipant)
-			.build();
-
+		PartyJoin partyJoin = PartyJoin.genertaeWaitingPartyJoin(partyParticipant, selectedOtt);
 		partyJoinRepository.save(partyJoin);
 
 		return partyJoin.getId();
+	}
+
+	@Transactional
+	public void joinParty(final PartyJoin partyJoin, final PartyCapsule partyCapsule) {
+		verifyWaitingPartyJoin(partyJoin);
+		verifyEmptyPartyCapsule(partyCapsule);
+
+		PartyJoin partyJoinReference = partyJoinRepository.getReferenceById(partyJoin.getId());
+		User userReference = userRepository.getReferenceById(partyJoin.getUser().getId());
+		PartyCapsule partyCapsuleReference = partyCapsuleRepository.getReferenceById(partyCapsule.getId());
+
+		partyCapsuleRepository.updatePartyCapusuleOccupy(userReference, partyCapsuleReference);
+		partyJoinRepository.updatePartyJoinPayWaiting(partyJoinReference);
+	}
+
+	private void verifyEmptyPartyCapsule(PartyCapsule partyCapsule) {
+		if (!partyCapsule.isEmptyCapsule()) {
+			throw new IllegalArgumentException("파티 캡슐의 상태가 빈 상태가 아닙니다.");
+		}
+	}
+
+	private void verifyWaitingPartyJoin(PartyJoin partyJoin) {
+		if (!partyJoin.isWaitingPartyJoin()) {
+			throw new IllegalArgumentException("파티 조인의 상태가 대기 상태가 아닙니다.");
+		}
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -129,15 +129,19 @@ public class PartyService {
 
 	@Transactional
 	public void joinParty(final PartyJoin partyJoin, final PartyCapsule partyCapsule) {
-		verifyWaitingPartyJoin(partyJoin);
-		verifyEmptyPartyCapsule(partyCapsule);
+		PartyJoin partyJoinPersist = partyJoinRepository.findByIdForUpdate(partyJoin.getId())
+			.orElseThrow(
+				() -> new IllegalArgumentException("partyJoin 엔티티가 존재하지 않음. partyJoinId = " + partyJoin.getId()));
 
-		PartyJoin partyJoinReference = partyJoinRepository.getReferenceById(partyJoin.getId());
-		User userReference = userRepository.getReferenceById(partyJoin.getUser().getId());
-		PartyCapsule partyCapsuleReference = partyCapsuleRepository.getReferenceById(partyCapsule.getId());
+		PartyCapsule partyCapsulePersist = partyCapsuleRepository.findByIdForUpdate(partyCapsule.getId())
+			.orElseThrow(
+				() -> new IllegalArgumentException("partyCapsule 엔티티가 존재하지 않음. partyCapsuleId = " + partyJoin.getId()));
 
-		partyCapsuleRepository.updatePartyCapusuleOccupy(userReference, partyCapsuleReference);
-		partyJoinRepository.updatePartyJoinPayWaiting(partyJoinReference);
+		verifyWaitingPartyJoin(partyJoinPersist);
+		verifyEmptyPartyCapsule(partyCapsulePersist);
+
+		partyCapsulePersist.occupy(partyJoin.getUser());
+		partyJoinPersist.changeStatusPayWaiting();
 	}
 
 	private void verifyEmptyPartyCapsule(PartyCapsule partyCapsule) {

--- a/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
@@ -1,0 +1,27 @@
+package com.flab.weshare.domain.partyMatch.schedule;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.flab.weshare.domain.party.entity.Ott;
+import com.flab.weshare.domain.party.repository.OttRepository;
+import com.flab.weshare.domain.partyMatch.service.PartyMatchingService;
+
+@Component
+public class PartyMatchingScheduler {
+	@Autowired
+	PartyMatchingService partyMatchingService;
+
+	@Autowired
+	OttRepository ottRepository;
+
+	@Scheduled(cron = "0/10 * * * * *")
+	//@Scheduled(cron = "0 0 0/1 * * *") //1시간 마다
+	public void partyMatchingSchedule() {
+		List<Ott> otts = ottRepository.findAll();
+		otts.forEach(partyMatchingService::partyMatch);
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
@@ -9,9 +9,15 @@ import org.springframework.stereotype.Component;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.repository.OttRepository;
 import com.flab.weshare.domain.partyMatch.service.PartyMatchingService;
+import com.flab.weshare.domain.partyMatch.service.util.TaskManager;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
 public class PartyMatchingScheduler {
+	private final TaskManager<Long> taskManager = new TaskManager<>();
+
 	@Autowired
 	PartyMatchingService partyMatchingService;
 
@@ -21,7 +27,22 @@ public class PartyMatchingScheduler {
 	@Scheduled(cron = "0/10 * * * * *")
 	//@Scheduled(cron = "0 0 0/1 * * *") //1시간 마다
 	public void partyMatchingSchedule() {
+		log.info("주기 작업 시작");
 		List<Ott> otts = ottRepository.findAll();
-		otts.forEach(partyMatchingService::partyMatch);
+		for (Ott ott : otts) {
+			try {
+				runPartyMatchByOtt(ott);
+			} catch (Exception e) {
+				log.error("파티 매칭 비동기 메서드 호출시 에러", e);
+			}
+		}
+		log.info("주기 작업 호출 끝");
+	}
+
+	private void runPartyMatchByOtt(Ott ott) {
+		if (taskManager.addTask(ott.getId())) {
+			partyMatchingService.partyMatch(ott)
+				.thenAccept(taskManager::removeTask);
+		}
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/schedule/PartyMatchingScheduler.java
@@ -27,7 +27,6 @@ public class PartyMatchingScheduler {
 	@Scheduled(cron = "0/10 * * * * *")
 	//@Scheduled(cron = "0 0 0/1 * * *") //1시간 마다
 	public void partyMatchingSchedule() {
-		log.info("주기 작업 시작");
 		List<Ott> otts = ottRepository.findAll();
 		for (Ott ott : otts) {
 			try {
@@ -36,7 +35,6 @@ public class PartyMatchingScheduler {
 				log.error("파티 매칭 비동기 메서드 호출시 에러", e);
 			}
 		}
-		log.info("주기 작업 호출 끝");
 	}
 
 	private void runPartyMatchByOtt(Ott ott) {

--- a/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
@@ -1,10 +1,10 @@
 package com.flab.weshare.domain.partyMatch.service;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyCapsule;
@@ -24,11 +24,10 @@ public class PartyMatchingService {
 	private final PartyCapsuleRepository partyCapsuleRepository;
 	private final PartyJoinRepository partyJoinRepository;
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void partyMatch(final Ott ott) {
+	@Async
+	public CompletableFuture<Long> partyMatch(final Ott ott) {
 		List<PartyCapsule> partyCapsules = partyCapsuleRepository.findEmptyCapsuleByOtt(ott);
 		List<PartyJoin> partyJoins = partyJoinRepository.findWaitingPartyJoinByOtt(ott);
-
 		int countMatchable = Math.min(partyCapsules.size(), partyJoins.size());
 
 		for (int i = 0; i < countMatchable; i++) {
@@ -41,5 +40,6 @@ public class PartyMatchingService {
 				log.error("partyJoin id ={}, partyCapsuleId= {} ", partyJoin.getId(), partyCapsule.getId());
 			}
 		}
+		return CompletableFuture.completedFuture(ott.getId());
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
@@ -3,6 +3,7 @@ package com.flab.weshare.domain.partyMatch.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.weshare.domain.party.entity.Ott;
@@ -23,7 +24,7 @@ public class PartyMatchingService {
 	private final PartyCapsuleRepository partyCapsuleRepository;
 	private final PartyJoinRepository partyJoinRepository;
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void partyMatch(final Ott ott) {
 		List<PartyCapsule> partyCapsules = partyCapsuleRepository.findEmptyCapsuleByOtt(ott);
 		List<PartyJoin> partyJoins = partyJoinRepository.findWaitingPartyJoinByOtt(ott);

--- a/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/service/PartyMatchingService.java
@@ -1,0 +1,44 @@
+package com.flab.weshare.domain.partyMatch.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.flab.weshare.domain.party.entity.Ott;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.party.entity.PartyJoin;
+import com.flab.weshare.domain.party.repository.PartyCapsuleRepository;
+import com.flab.weshare.domain.party.repository.PartyJoinRepository;
+import com.flab.weshare.domain.party.service.PartyService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PartyMatchingService {
+	private final PartyService partyService;
+	private final PartyCapsuleRepository partyCapsuleRepository;
+	private final PartyJoinRepository partyJoinRepository;
+
+	@Transactional
+	public void partyMatch(final Ott ott) {
+		List<PartyCapsule> partyCapsules = partyCapsuleRepository.findEmptyCapsuleByOtt(ott);
+		List<PartyJoin> partyJoins = partyJoinRepository.findWaitingPartyJoinByOtt(ott);
+
+		int countMatchable = Math.min(partyCapsules.size(), partyJoins.size());
+
+		for (int i = 0; i < countMatchable; i++) {
+			PartyJoin partyJoin = partyJoins.get(i);
+			PartyCapsule partyCapsule = partyCapsules.get(i);
+			try {
+				partyService.joinParty(partyJoin, partyCapsule);
+			} catch (Exception exception) {
+				log.error("파티 매칭 중 에러발생 {} ", exception.getMessage());
+				log.error("partyJoin id ={}, partyCapsuleId= {} ", partyJoin.getId(), partyCapsule.getId());
+			}
+		}
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/partyMatch/service/util/TaskManager.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/service/util/TaskManager.java
@@ -1,0 +1,24 @@
+package com.flab.weshare.domain.partyMatch.service.util;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class TaskManager<T> {
+	private Set<T> taskSet = ConcurrentHashMap.newKeySet();
+
+	public boolean addTask(T task) {
+		log.info("{} 번째 ottID 작업 시작", task);
+		return taskSet.add(task);
+	}
+
+	public void removeTask(T task) {
+		log.info("{} 번째 ottID 작업 종료", task);
+		taskSet.remove(task);
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/partyMatch/service/util/TaskManager.java
+++ b/src/main/java/com/flab/weshare/domain/partyMatch/service/util/TaskManager.java
@@ -7,18 +7,15 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 public class TaskManager<T> {
 	private Set<T> taskSet = ConcurrentHashMap.newKeySet();
 
 	public boolean addTask(T task) {
-		log.info("{} 번째 ottID 작업 시작", task);
 		return taskSet.add(task);
 	}
 
 	public void removeTask(T task) {
-		log.info("{} 번째 ottID 작업 종료", task);
 		taskSet.remove(task);
 	}
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,4 +2,18 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
+    generate-ddl: false
+
+  sql:
+    init:
+      schema-locations: classpath:/sql/init.sql
+      mode: always
+
+async:
+  prefix: 'async-thread-'
+  corePoolSize: 20
+  maxPoolSize: 40
+  queueCapacity: 400
+  keepAliveSeconds: 30
+

--- a/src/test/java/com/flab/weshare/domain/party/repository/PartyJoinRepositoryTest.java
+++ b/src/test/java/com/flab/weshare/domain/party/repository/PartyJoinRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.flab.weshare.domain.party.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.flab.weshare.domain.base.BaseRepositoryTest;
+import com.flab.weshare.domain.party.entity.PartyJoin;
+import com.flab.weshare.domain.party.entity.PartyJoinStatus;
+
+import jakarta.persistence.EntityManager;
+
+class PartyJoinRepositoryTest extends BaseRepositoryTest {
+	@Autowired
+	PartyJoinRepository partyJoinRepository;
+
+	@Autowired
+	EntityManager em;
+
+	@Test
+	void findWaitingPartyJoinByOtt() {
+		em.clear();
+		List<PartyJoin> partyJoin = createPartyJoin();
+
+		PartyJoin.builder()
+			.user(userRepository.getReferenceById(1L));
+		List<PartyJoin> waitingPartyJoinByOtt = partyJoinRepository.findWaitingPartyJoinByOtt(testOtt);
+
+		Assertions.assertThat(waitingPartyJoinByOtt).hasSize(partyJoin.size());
+	}
+
+	private List<PartyJoin> createPartyJoin() {
+		List<PartyJoin> partyJoins = new ArrayList<>();
+		for (int i = 1; i < 6; i++) {
+			PartyJoin partyJoin = PartyJoin.genertaeWaitingPartyJoin(userRepository.getReferenceById((long)i), testOtt);
+			partyJoins.add(partyJoin);
+			partyJoinRepository.save(partyJoin);
+		}
+
+		for (int i = 6; i < 10; i++) {
+			PartyJoin partyJoin = PartyJoin.builder()
+				.user(userRepository.getReferenceById((long)i))
+				.ott(testOtt)
+				.partyJoinStatus(PartyJoinStatus.JOINED)
+				.build();
+			partyJoinRepository.save(partyJoin);
+		}
+		return partyJoins;
+	}
+
+}


### PR DESCRIPTION
## 설명
- [#17] 파티 매칭구현

## 부가설명
+ 해당 기능을 구현하기 위해 `spring batch`를 고려하는 과정에서 해당 작업이 과연 배치 작업에 적합한가에 대한 의문이 들었습니다.
+ 현재 파티 매칭 기능의 주안점은 주기적인 작업의 반복이며, 대용량 처리에 주안점을 두는 배치의 사용의 필요성을 느끼지 못해서 이부분을 `spring scheduler`를 사용하여 단순 주기작업으로 먼저 작성을 해보았습니다. 
+ 향후 멘토님과 논의 후 이부분을 개선할 수 있는 방안을 모색해보겠습니다. 
+ 반복작업에서 트랜잭션관리와 예외처리를 통해 실시되어야하는 전체 파티매칭에 미치는 영향을 최소화하는데 집중했습니다.
