### PR TITLE
[#27] 유저 파티 관련 조회 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.batch:spring-batch-integration'
-
+    implementation 'org.springframework.boot:spring-boot-starter-hateoas:2.6.6'
     testImplementation 'org.projectlombok:lombok'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
+++ b/src/main/java/com/flab/weshare/domain/party/controller/PartyController.java
@@ -1,7 +1,14 @@
 package com.flab.weshare.domain.party.controller;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -11,7 +18,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.weshare.domain.base.BaseResponse;
+import com.flab.weshare.domain.party.dto.LeadingPartySummary;
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.ParticipatedPartyDto;
+import com.flab.weshare.domain.party.dto.ParticipatingPartySummary;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
 import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.service.PartyService;
@@ -56,5 +66,45 @@ public class PartyController {
 		Long generatedPartyJoinId = partyService.generatePartyJoin(partyJoinRequest, jwtAuthentication.getId());
 
 		return BaseResponse.created(generatedPartyJoinId);
+	}
+
+	@GetMapping("/my")
+	@ResponseStatus(HttpStatus.OK)
+	public BaseResponse getAllParticipatedParties(@AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
+		ParticipatedPartyDto allParticipatedParties = partyService.findAllParticipatedParties(
+			jwtAuthentication.getId());
+
+		List<EntityModel<LeadingPartySummary>> result1 = allParticipatedParties.getLeadingParties()
+			.stream().map(leadingPartySummary ->
+				EntityModel.of(leadingPartySummary, linkTo(
+					methodOn(PartyController.class).getParty(leadingPartySummary.partyId(), null)).withSelfRel()))
+			.toList();
+
+		List<EntityModel<ParticipatingPartySummary>> result2 = allParticipatedParties.getParticipatingParties()
+			.stream().map(participatingPartySummary ->
+				EntityModel.of(participatingPartySummary, linkTo(
+					methodOn(PartyController.class).getPartyCapsule(participatingPartySummary.partyCapsuleId(),
+						null)).withSelfRel()))
+			.toList();
+
+		EntityModel<Map<String, List<? extends EntityModel<? extends Record>>>> data = EntityModel.of(
+			Map.of("leadingParties", result1, "participatingParties", result2),
+			linkTo(methodOn(PartyController.class).getAllParticipatedParties(null)).withSelfRel());
+
+		return BaseResponse.success(data);
+	}
+
+	@GetMapping("/{partyId}")
+	@ResponseStatus(HttpStatus.OK)
+	public BaseResponse getParty(@PathVariable final Long partyId,
+		@AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
+		return BaseResponse.success(partyService.getPartyInfo(partyId, jwtAuthentication.getId()));
+	}
+
+	@GetMapping("/participated/{partyCapsuleId}")
+	@ResponseStatus(HttpStatus.OK)
+	public BaseResponse getPartyCapsule(
+		@PathVariable final Long partyCapsuleId, @AuthenticationPrincipal final JwtAuthentication jwtAuthentication) {
+		return BaseResponse.success(partyService.getPartyCapsuleInfo(partyCapsuleId, jwtAuthentication.getId()));
 	}
 }

--- a/src/main/java/com/flab/weshare/domain/party/dto/LeadingPartySummary.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/LeadingPartySummary.java
@@ -1,0 +1,11 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.time.LocalDate;
+
+import com.flab.weshare.domain.party.entity.Party;
+
+public record LeadingPartySummary(Long partyId, LocalDate startDate, String ottName) {
+	public static LeadingPartySummary of(Party party) {
+		return new LeadingPartySummary(party.getId(), party.getCreatedDate().toLocalDate(), party.getOtt().getName());
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/ParticipantSummary.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/ParticipantSummary.java
@@ -1,0 +1,22 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public record ParticipantSummary(String nickName, LocalDate startDate, String status) {
+	public static ParticipantSummary of(PartyCapsule partyCapsule) {
+		if (partyCapsule.isEmptyCapsule()) {
+			return ParticipantSummary.builder().status("empty").build();
+		}
+		return ParticipantSummary.builder()
+			.nickName(partyCapsule.getPartyMember().getNickName())
+			.startDate(partyCapsule.getJoinDate())
+			.status("occupied").build();
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/ParticipatedPartyDto.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/ParticipatedPartyDto.java
@@ -1,0 +1,13 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ParticipatedPartyDto {
+	private final List<LeadingPartySummary> leadingParties;
+	private final List<ParticipatingPartySummary> participatingParties;
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/ParticipatingPartySummary.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/ParticipatingPartySummary.java
@@ -1,0 +1,12 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.time.LocalDate;
+
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+
+public record ParticipatingPartySummary(Long partyCapsuleId, LocalDate startDate, String ottName) {
+	public static ParticipatingPartySummary of(PartyCapsule partyCapsule) {
+		return new ParticipatingPartySummary(partyCapsule.getId(), partyCapsule.getJoinDate(),
+			partyCapsule.getParty().getOtt().getName());
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/PartyCapsuleInfo.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/PartyCapsuleInfo.java
@@ -1,0 +1,26 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.time.LocalDate;
+
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+
+import lombok.Builder;
+
+@Builder
+public record PartyCapsuleInfo(Long partyCapsuleId,
+							   LocalDate startDate,
+							   LocalDate expirationDate,
+							   String ottName,
+							   boolean cancelReservation,
+							   String status) {
+	public static PartyCapsuleInfo of(PartyCapsule partyCapsule) {
+		return PartyCapsuleInfo.builder()
+			.partyCapsuleId(partyCapsule.getId())
+			.expirationDate(partyCapsule.getExpirationDate())
+			.cancelReservation(partyCapsule.isCancelReservation())
+			.ottName(partyCapsule.getParty().getOtt().getName())
+			.startDate(partyCapsule.getJoinDate())
+			.status(partyCapsule.getPartyCapsuleStatus().toString())
+			.build();
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/dto/PartyInfo.java
+++ b/src/main/java/com/flab/weshare/domain/party/dto/PartyInfo.java
@@ -1,0 +1,32 @@
+package com.flab.weshare.domain.party.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.party.entity.PartyCapsule;
+
+public record PartyInfo(Long partyId,
+						List<ParticipantSummary> participants,
+						LocalDate startDate,
+						String ottName,
+						String ottAccountId,
+						String ottAccountPassword) {
+
+	public static PartyInfo of(final Party party) {
+		return new PartyInfo(
+			party.getId(),
+			participantSummaries(party.getPartyCapsules()),
+			party.getCreatedDate().toLocalDate(),
+			party.getOtt().getName(),
+			party.getOttAccountId(),
+			party.getOttAccountPassword()
+		);
+	}
+
+	private static List<ParticipantSummary> participantSummaries(final List<PartyCapsule> capsules) {
+		return capsules.stream()
+			.map(ParticipantSummary::of)
+			.toList();
+	}
+}

--- a/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
+++ b/src/main/java/com/flab/weshare/domain/party/entity/PartyCapsule.java
@@ -40,18 +40,22 @@ public class PartyCapsule extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private PartyCapsuleStatus partyCapsuleStatus;
 
-	/**
-	 * 현재 파티캡슐 만료 날짜
-	 */
 	private LocalDate expirationDate;
+
+	private LocalDate joinDate;
 
 	private boolean cancelReservation;
 
 	@Builder
-	private PartyCapsule(User partyMember, Party party, PartyCapsuleStatus partyCapsuleStatus) {
+	public PartyCapsule(Long id, User partyMember, Party party, PartyCapsuleStatus partyCapsuleStatus,
+		LocalDate expirationDate, LocalDate joinDate, boolean cancelReservation) {
+		this.id = id;
 		this.partyMember = partyMember;
 		this.party = party;
 		this.partyCapsuleStatus = partyCapsuleStatus;
+		this.expirationDate = expirationDate;
+		this.joinDate = joinDate;
+		this.cancelReservation = cancelReservation;
 	}
 
 	public static PartyCapsule makeEmptyCapsule(Party party) {

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyCapsuleRepository.java
@@ -15,6 +15,7 @@ import org.springframework.data.repository.query.Param;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.PartyCapsule;
 import com.flab.weshare.domain.party.entity.PartyCapsuleStatus;
+import com.flab.weshare.domain.user.entity.User;
 
 import jakarta.persistence.LockModeType;
 
@@ -47,4 +48,19 @@ public interface PartyCapsuleRepository extends JpaRepository<PartyCapsule, Long
 		+ "where pc in :partyCapsules")
 	void updateAllExpirationDate(@Param("expirationDate") LocalDateTime expirationDate,
 		@Param("partyCapsules") List<PartyCapsule> partyCapsules);
+
+	@Query(value = "select pc "
+		+ "from PartyCapsule pc "
+		+ "join fetch pc.party pcp "
+		+ "join fetch pcp.ott "
+		+ "where pc.partyMember =:user and pc.partyCapsuleStatus =:status")
+	List<PartyCapsule> findAllPartyCapsulesUserId(@Param("status") PartyCapsuleStatus partyCapsuleStatus,
+		@Param("user") User user);
+
+	@Query(value = "select pc "
+		+ "from PartyCapsule pc "
+		+ "join fetch pc.party pcp "
+		+ "join fetch pcp.ott "
+		+ "where pc.id =:id")
+	Optional<PartyCapsule> findPartyCapsuleById(@Param("id") Long partyCapsuleId);
 }

--- a/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
+++ b/src/main/java/com/flab/weshare/domain/party/repository/PartyRepository.java
@@ -1,5 +1,6 @@
 package com.flab.weshare.domain.party.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,9 +8,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.user.entity.User;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
-
 	@Query("select distinct p "
 		+ "from Party p "
 		+ "join fetch p.partyCapsules pc "
@@ -18,4 +19,10 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 		+ "and pc.partyCapsuleStatus in (com.flab.weshare.domain.party.entity.PartyCapsuleStatus.EMPTY,"
 		+ "com.flab.weshare.domain.party.entity.PartyCapsuleStatus.OCCUPIED)")
 	Optional<Party> findFetchByPartyId(@Param("partyId") Long partyId);
+
+	@Query("select p "
+		+ "from Party p "
+		+ "join fetch p.ott "
+		+ "where p.leader =:user")
+	List<Party> findByUserIdWithOtt(@Param("user") User user);
 }

--- a/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
+++ b/src/main/java/com/flab/weshare/domain/party/service/PartyService.java
@@ -7,12 +7,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.flab.weshare.domain.party.dto.LeadingPartySummary;
 import com.flab.weshare.domain.party.dto.ModifyPartyRequest;
+import com.flab.weshare.domain.party.dto.ParticipatedPartyDto;
+import com.flab.weshare.domain.party.dto.ParticipatingPartySummary;
+import com.flab.weshare.domain.party.dto.PartyCapsuleInfo;
 import com.flab.weshare.domain.party.dto.PartyCreationRequest;
+import com.flab.weshare.domain.party.dto.PartyInfo;
 import com.flab.weshare.domain.party.dto.PartyJoinRequest;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.Party;
 import com.flab.weshare.domain.party.entity.PartyCapsule;
+import com.flab.weshare.domain.party.entity.PartyCapsuleStatus;
 import com.flab.weshare.domain.party.entity.PartyJoin;
 import com.flab.weshare.domain.party.repository.OttRepository;
 import com.flab.weshare.domain.party.repository.PartyCapsuleRepository;
@@ -22,6 +28,8 @@ import com.flab.weshare.domain.user.entity.User;
 import com.flab.weshare.domain.user.repository.UserRepository;
 import com.flab.weshare.exception.ErrorCode;
 import com.flab.weshare.exception.exceptions.CommonClientException;
+import com.flab.weshare.exception.exceptions.CommonNotFoundException;
+import com.flab.weshare.exception.exceptions.UnsatisfiedAuthorityException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -153,6 +161,46 @@ public class PartyService {
 	private void verifyWaitingPartyJoin(PartyJoin partyJoin) {
 		if (!partyJoin.isWaitingPartyJoin()) {
 			throw new IllegalArgumentException("파티 조인의 상태가 대기 상태가 아닙니다.");
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public ParticipatedPartyDto findAllParticipatedParties(final Long userId) {
+		log.info("userId {}", userId);
+		User referenceById = userRepository.getReferenceById(userId);
+		List<LeadingPartySummary> leadingPartySummaries = partyRepository.findByUserIdWithOtt(referenceById)
+			.stream()
+			.map(LeadingPartySummary::of)
+			.toList();
+
+		List<ParticipatingPartySummary> participatingPartySummaries = partyCapsuleRepository.findAllPartyCapsulesUserId(
+				PartyCapsuleStatus.OCCUPIED, referenceById)
+			.stream().map(ParticipatingPartySummary::of)
+			.toList();
+
+		return new ParticipatedPartyDto(leadingPartySummaries, participatingPartySummaries);
+	}
+
+	@Transactional(readOnly = true)
+	public PartyInfo getPartyInfo(Long partyId, Long userId) {
+		Party party = partyRepository.findFetchByPartyId(partyId)
+			.orElseThrow(() -> new CommonNotFoundException(ErrorCode.makeSpecificResourceNotFoundErrorCode("party ")));
+		checkAuthority(userId, party.getLeader().getId());
+		return PartyInfo.of(party);
+	}
+
+	@Transactional(readOnly = true)
+	public PartyCapsuleInfo getPartyCapsuleInfo(Long partyCapsuleId, Long userId) {
+		PartyCapsule partyCapsule = partyCapsuleRepository.findPartyCapsuleById(partyCapsuleId)
+			.orElseThrow(
+				() -> new CommonNotFoundException(ErrorCode.makeSpecificResourceNotFoundErrorCode("partyCapsule ")));
+		checkAuthority(userId, partyCapsule.getPartyMember().getId());
+		return PartyCapsuleInfo.of(partyCapsule);
+	}
+
+	private void checkAuthority(Long userId, Long targetId) {
+		if (!userId.equals(targetId)) {
+			throw new UnsatisfiedAuthorityException(ErrorCode.INSUFFICIENT_AUTHORITY);
 		}
 	}
 }

--- a/src/main/java/com/flab/weshare/exception/ErrorCode.java
+++ b/src/main/java/com/flab/weshare/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public class ErrorCode {
 		"DB 오류가 발생했습니다.");
 	public static final ErrorCode FAIL_CARD_ENROLLMENT = new ErrorCode("FAIL_CARD_ENROLLMENT",
 		"카드 등록에 실패했습니다.");
+	public static final ErrorCode INSUFFICIENT_AUTHORITY = new ErrorCode("INSUFFICIENT_AUTHORITY",
+		"권한이 부족한 요청입니다.");
 
 	private final String errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
+++ b/src/main/java/com/flab/weshare/exception/advice/ControllerAdvice.java
@@ -13,6 +13,8 @@ import com.flab.weshare.domain.base.BaseResponse;
 import com.flab.weshare.domain.base.ErrorResponse;
 import com.flab.weshare.exception.ErrorCode;
 import com.flab.weshare.exception.exceptions.CommonClientException;
+import com.flab.weshare.exception.exceptions.CommonNotFoundException;
+import com.flab.weshare.exception.exceptions.UnsatisfiedAuthorityException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +40,18 @@ public class ControllerAdvice {
 	public BaseResponse commonExceptionHandler(CommonClientException commonClientException) {
 		log.error("exception :", commonClientException);
 		return BaseResponse.fail(ErrorResponse.of(commonClientException.getErrorCode()));
+	}
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(CommonNotFoundException.class)
+	public BaseResponse commonNotFoundException(CommonNotFoundException commonNotFoundException) {
+		return BaseResponse.fail(ErrorResponse.of(commonNotFoundException.getErrorCode()));
+	}
+
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	@ExceptionHandler(UnsatisfiedAuthorityException.class)
+	public BaseResponse commonNotFoundException(UnsatisfiedAuthorityException commonNotFoundException) {
+		return BaseResponse.fail(ErrorResponse.of(commonNotFoundException.getErrorCode()));
 	}
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/flab/weshare/exception/exceptions/CommonNotFoundException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/CommonNotFoundException.java
@@ -1,0 +1,12 @@
+package com.flab.weshare.exception.exceptions;
+
+import com.flab.weshare.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommonNotFoundException extends RuntimeException {
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/flab/weshare/exception/exceptions/UnsatisfiedAuthorityException.java
+++ b/src/main/java/com/flab/weshare/exception/exceptions/UnsatisfiedAuthorityException.java
@@ -1,0 +1,12 @@
+package com.flab.weshare.exception.exceptions;
+
+import com.flab.weshare.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UnsatisfiedAuthorityException extends RuntimeException {
+	private final ErrorCode errorCode;
+}

--- a/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
+++ b/src/test/java/com/flab/weshare/domain/base/BaseControllerTest.java
@@ -2,6 +2,7 @@ package com.flab.weshare.domain.base;
 
 import static com.flab.weshare.domain.utils.TestUtil.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,7 @@ public abstract class BaseControllerTest {
 	EntityManager entityManager;
 
 	@Autowired
-	JwtUtil jwtUtil;
+	protected JwtUtil jwtUtil;
 
 	protected String ACCESS_TOKEN;
 	protected String REFRESH_TOKEN;
@@ -77,9 +78,17 @@ public abstract class BaseControllerTest {
 		List<User> users = createUsers();
 		userRepository.saveAll(users);
 
+		PartyCapsule partyCapsule = PartyCapsule.builder()
+			.party(partyRepository.getReferenceById(2L))
+			.partyMember(savedUser)
+			.partyCapsuleStatus(PartyCapsuleStatus.OCCUPIED)
+			.joinDate(LocalDate.now())
+			.build();
+		partyCapsuleRepository.save(partyCapsule);
 		List<PartyCapsule> partyCapsules = createPartyCapsules(users);
 		partyCapsuleRepository.saveAll(partyCapsules);
 
+		entityManager.flush();
 		entityManager.clear();
 	}
 
@@ -90,6 +99,7 @@ public abstract class BaseControllerTest {
 				.party(savedParty)
 				.partyMember(users.get(i))
 				.partyCapsuleStatus(PartyCapsuleStatus.OCCUPIED)
+				.joinDate(LocalDate.now())
 				.build();
 			partyCapsules.add(partyCapsule);
 		}

--- a/src/test/java/com/flab/weshare/domain/utils/TestUtil.java
+++ b/src/test/java/com/flab/weshare/domain/utils/TestUtil.java
@@ -2,8 +2,10 @@ package com.flab.weshare.domain.utils;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import com.flab.weshare.domain.base.Money;
 import com.flab.weshare.domain.party.entity.Ott;
 import com.flab.weshare.domain.party.entity.Party;
+import com.flab.weshare.domain.user.entity.Role;
 import com.flab.weshare.domain.user.entity.User;
 
 public class TestUtil {
@@ -21,6 +23,7 @@ public class TestUtil {
 		.password(bCryptPasswordEncoder.encode(PASSWORD))
 		.nickName(NICKNAME)
 		.telephone(TELEPHONE)
+		.role(Role.CLIENT)
 		.build();
 
 	//Ott
@@ -33,10 +36,9 @@ public class TestUtil {
 	public static final Ott savedOtt = Ott
 		.builder()
 		.name(OTT_NAME)
-		.leaderFee(LEADER_FEE)
-		.commonFee(COMMON_FEE)
 		.maximumCapacity(MAXIMUM_CAPACITY)
 		.minimumCapacity(MINIMUM_CAPACITY)
+		.perDayPrice(new Money(1000))
 		.build();
 
 	//Party

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,14 +5,37 @@ spring:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8:///
 
+  batch:
+    job:
+      name: ${job.name:NONE}
+      enabled: false
+    jdbc:
+      initialize-schema: always
   jpa:
     open-in-view: false
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true
     hibernate:
-      ddl-auto: create
-    database-platform: org.hibernate.dialect.MySQLDialect
+      ddl-auto: none
+    generate-ddl: false
+
+  sql:
+    init:
+      schema-locations: classpath:/sql/init.sql
+      mode: always
+
+async:
+  prefix: 'async-thread-'
+  corePoolSize: 20
+  maxPoolSize: 40
+  queueCapacity: 400
+  keepAliveSeconds: 30
 
 jwt:
   access_expiration_time: ${JWT_ACCESS_EXPIRATION_TIME}
   refresh_expiration_time: ${JWT_REFRESH_EXPIRATION_TIME}
   secret: ${JWT_SECRET}
 
+pay:
+  rest_application_id: ${REST_APPLICATION_ID}
+  private_key: ${PRIVATE_KEY}


### PR DESCRIPTION
## 설명
- [#27] 유저의 파티 관련 조회 api 구현

## 작업 내용
- 유저의 관련된 파티 목록 조회 api 구현 
  - `Hateoas`를 적용하여 서버와 클라이언트 간의 결합도 저하를 고려
- 운영 중인 파티 상세 조회 api 구현
  - 상세 조회 시 `pathVariable`을 사용하고 리소스가 존재하지 않을시 `404 Not found` 반환
  - 파티의 소유주와 요청 하는 유저가 동일하지 않을 시 `403 Forbidden` 반환
- 참여 중인 파티 상세 조회 api 구현 
  - 위와 동일
- 비즈니스 로직 단위 테스트 시 `mocking`을 사용한 예외 상황 테스트
