### PR TITLE
ci/cd 스크립트 분리 적용 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
         stage('check chore') {
             steps {
                 script {
+                    echo "Branch ${env.BRANCH_NAME}"
                     if (env.BRANCH_NAME == 'main') {
+
                         def changes = sh(script: 'git diff --name-only HEAD~1', returnStdout: true).trim()
                         if (changes == 'README.md') {
                             currentBuild.result = 'SUCCESS'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                         }
                     }
 
-                    if (env.BRANCH_NAME.startsWith('chore') || env.BRANCH_NAME.startsWith('docs') {
+                    if (env.BRANCH_NAME.startsWith('chore') || env.BRANCH_NAME.startsWith('docs')) {
                         currentBuild.result = 'SUCCESS'
                         return
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,22 @@ pipeline {
         jdk("java17")
     }
 
+    //CI
     stages {
+        stage('check chore') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME == 'main') {
+                        def changes = sh(script: 'git diff --name-only HEAD~1', returnStdout: true).trim()
+                        if (changes == 'README.md') {
+                            currentBuild.result = 'SUCCESS'
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Checkout Git') {
             steps {
                 script {
@@ -34,6 +49,18 @@ pipeline {
             }
         }
 
+        stage('check CI') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME != 'main') {
+                        currentBuild.result = 'SUCCESS'
+                        return
+                    }
+                }
+            }
+        }
+
+        // CD
         stage('configure deploy variables') {
             steps {
                 script {


### PR DESCRIPTION
## 설명
- 브랜치명에 따른 ci/cd 적용을 분리.

## 목표
- `main` 브랜치에 push 이벤트 발생시 `cd` 스크립트 작동
- `docs` `chore`를 제외한 모든 브랜치에서 `ci` 적용


